### PR TITLE
Use DocBook 4.2 DTD

### DIFF
--- a/docs/man_fix.xsl
+++ b/docs/man_fix.xsl
@@ -6,8 +6,8 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <xsl:output method="xml"
-                doctype-system="http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
-                doctype-public="-//OASIS//DTD DocBook XML V4.1.2//EN"/>
+                doctype-system="http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
+                doctype-public="-//OASIS//DTD DocBook XML V4.2//EN"/>
 
     <xsl:template match="node()|@*">
         <xsl:copy>


### PR DESCRIPTION
Hello,

I needed 1.5's new line-wrapping behavior so I checked out the source. I had trouble building because xmlto was throwing validation errors for the manpage. Turns out the 'email' element was not yet supported in DocBook 4.1.2 - the 4.2 DTD needs to be used. 

I'm probably doing something silly or unusual, since I'm getting an error you presumably are not getting. So thanks for your consideration of a 'commit from the blue'.
