### PR TITLE
cfstring.h has been relocated on Mac in wxWidgets 2.9

### DIFF
--- a/src/gexecute.cpp
+++ b/src/gexecute.cpp
@@ -33,7 +33,11 @@
 #include <wx/intl.h>
 
 #ifdef __WXMAC__
+#if wxCHECK_VERSION(2, 9, 0)
+#include <wx/osx/core/cfstring.h>
+#else
 #include <wx/mac/corefoundation/cfstring.h>
+#endif
 #include <CoreFoundation/CFBundle.h>
 #endif
 


### PR DESCRIPTION
This fix was necessary for me to build the program with wxWidgets 2.9 on Mac since the file has been relocated (even though compilation didn't succeed to the end).

See also:
- http://docs.wxwidgets.org/2.9.3/page_cppconst.html
- http://docs.wxwidgets.org/2.8.12/wx_cppconst.html#cppconst
- http://docs.wxwidgets.org/2.8/wx_versionfunctions.html
- location: http://trac.wxwidgets.org/browser/wxWidgets/tags/WX_2_9_0/include/wx/osx/core/cfstring.h
  (one could in principle also check for **WXOSX**)
