### PR TITLE
Updated Lithuanian translation

### DIFF
--- a/locales/lt.po
+++ b/locales/lt.po
@@ -6,23 +6,27 @@
 # Kestutis Snieška <sniekest@pit.ktu.lt>, 2003
 # Ramūnas Lukaševičius <Ramunas.Lukasevicius@mail.lt>, 2003
 # Gintautas Miliauskas <gintas@akl.lt>, 2006
+# Algimantas Margevičius <margevicius.algimantas@gmail.com>, 2012.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Poedit 1.5\n"
 "Report-Msgid-Bugs-To: poedit@googlegroups.com\n"
 "POT-Creation-Date: 2012-07-30 10:34+0200\n"
-"PO-Revision-Date: 2010-11-23 23:08+0100\n"
-"Last-Translator: Andrius Štikonas <stikonas@gmail.com>\n"
-"Language-Team: lt <komp_lt@konferencijos.lt>\n"
+"PO-Revision-Date: 2012-11-14 14:54+0200\n"
+"Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>\n"
+"Language-Team: Lietuvių <>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Gtranslator 2.91.5\n"
 
 #: ../src/edframe.cpp:2060
 msgid " (modified)"
-msgstr " (pakeisti)"
+msgstr " (pakeista)"
 
 #. TRANSLATORS: This is version information in about dialog, it is followed
 #. by version number when used (wxWidgets 2.8)
@@ -34,22 +38,25 @@ msgstr " Versija"
 #, c-format
 msgid "%d issue with the translation found."
 msgid_plural "%d issues with the translation found."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Rasta %d vertimo problema."
+msgstr[1] "Rastos %d vertimo problemos."
+msgstr[2] "Rasta %d vertimo problemų."
 
 #: ../src/edframe.cpp:2024
-#, fuzzy, c-format
+#, c-format
 msgid "%i %% translated, %i string"
 msgid_plural "%i %% translated, %i strings"
-msgstr[0] "%i %% išversta, %i eilučių"
-msgstr[1] "%i %% išversta, %i eilučių"
+msgstr[0] "%i %% išversta, %i eilutė"
+msgstr[1] "%i %% išversta, %i eilutės"
+msgstr[2] "%i %% išversta, %i eilučių"
 
 #: ../src/edframe.cpp:2029
-#, fuzzy, c-format
+#, c-format
 msgid "%i %% translated, %i string (%s)"
 msgid_plural "%i %% translated, %i strings (%s)"
-msgstr[0] "%i %% išversta, %i eilučių (%s)"
-msgstr[1] "%i %% išversta, %i eilučių (%s)"
+msgstr[0] "%i %% išversta, %i eilutė (%s)"
+msgstr[1] "%i %% išversta, %i eilutės (%s)"
+msgstr[2] "%i %% išversta, %i eilučių (%s)"
 
 #: ../src/export_html.cpp:134
 #, c-format
@@ -59,39 +66,41 @@ msgstr ""
 "%i %% išversta, %i eilučių (%i neaiški, %i blogi skirtukai, %i neišversta)"
 
 #: ../src/edframe.cpp:2014
-#, fuzzy, c-format
+#, c-format
 msgid "%i bad token"
 msgid_plural "%i bad tokens"
-msgstr[0] "%i netaisyklingi skirtukai"
-msgstr[1] "%i netaisyklingi skirtukai"
+msgstr[0] "%i netinkamas skirtukas"
+msgstr[1] "%i netinkami skirtukai"
+msgstr[2] "%i netinkamų skirtukų"
 
 #: ../src/edframe.cpp:2008
-#, fuzzy, c-format
+#, c-format
 msgid "%i fuzzy"
 msgid_plural "%i fuzzy"
-msgstr[0] "%i neaiškių"
-msgstr[1] "%i neaiškių"
+msgstr[0] "%i neaiškus"
+msgstr[1] "%i neaiškūs"
+msgstr[2] "%i neaiškių"
 
 #: ../src/catalog.cpp:132
 #, c-format
 msgid "%i lines of file '%s' were not loaded correctly."
-msgstr "Nepavyko perskaityti %i eilučių iš failo '%s'."
+msgstr "Nepavyko perskaityti %i eilučių iš failo „%s“."
 
 #: ../src/edframe.cpp:2020
-#, fuzzy, c-format
+#, c-format
 msgid "%i not translated"
 msgid_plural "%i not translated"
 msgstr[0] "%i neišversta"
-msgstr[1] "%i neišversta"
+msgstr[1] "%i neišverstos"
+msgstr[2] "%i neišverstų"
 
 #: ../src/resources/menus.xrc:213 ../src/resources/menus.xrc:214
 msgid "&About"
 msgstr "&Apie"
 
 #: ../src/resources/menus.xrc:212
-#, fuzzy
 msgid "&About Poedit"
-msgstr "&Apie"
+msgstr "&Apie Poedit"
 
 #: ../src/resources/menus.xrc:107
 msgid "&Automatically Translate Using TM"
@@ -107,7 +116,7 @@ msgstr "Ž&ymelės"
 
 #: ../src/resources/manager.xrc:132 ../src/resources/menus.xrc:26
 msgid "&Close"
-msgstr "&Uždaryti"
+msgstr "&Užverti"
 
 #: ../src/resources/menus.xrc:176
 msgid "&Comment Window"
@@ -119,11 +128,11 @@ msgstr "&Komentarų langas"
 
 #: ../src/resources/menus.xrc:130
 msgid "&Done and Next"
-msgstr ""
+msgstr "&Atlikta ir Toliau"
 
 #: ../src/resources/menus.xrc:129
 msgid "&Done and next"
-msgstr ""
+msgstr "&Atlikta ir toliau"
 
 #: ../src/resources/menus.xrc:56
 msgid "&Edit"
@@ -144,7 +153,7 @@ msgstr "&Eiti"
 
 #: ../src/edapp.cpp:183 ../src/resources/menus.xrc:216
 msgid "&Help"
-msgstr "&Pagalba"
+msgstr "Ž&inynas"
 
 #: ../src/resources/menus.xrc:14
 msgid "&New Catalog..."
@@ -156,11 +165,11 @@ msgstr "&Naujas katalogas..."
 
 #: ../src/resources/menus.xrc:142
 msgid "&Next Message"
-msgstr ""
+msgstr "&Kitas pranešimas"
 
 #: ../src/resources/menus.xrc:141
 msgid "&Next message"
-msgstr ""
+msgstr "&Kitas pranešimas"
 
 #: ../src/resources/menus.xrc:206
 msgid "&Online Help"
@@ -184,11 +193,11 @@ msgstr "&Nustatymai..."
 
 #: ../src/resources/menus.xrc:137
 msgid "&Previous Message"
-msgstr ""
+msgstr "&Ankstesnis pranešimas"
 
 #: ../src/resources/menus.xrc:136
 msgid "&Previous message"
-msgstr ""
+msgstr "&Ankstesnis pranešimas"
 
 #: ../src/resources/menus.xrc:119
 msgid "&Properties..."
@@ -231,23 +240,21 @@ msgid "&Update from sources"
 msgstr "&Atnaujinti iš išeities tekstų"
 
 #: ../src/resources/menus.xrc:115
-#, fuzzy
 msgid "&Validate Translations"
-msgstr "Valyti vertimą"
+msgstr "&Tvirtinti vertimą"
 
 #: ../src/resources/menus.xrc:114
-#, fuzzy
 msgid "&Validate translations"
-msgstr "Valyti vertimą"
+msgstr "&Tvirtinti vertimą"
 
 #: ../src/resources/menus.xrc:157
 msgid "&View"
-msgstr "&Rodyti"
+msgstr "&Rodymas"
 
 #: ../src/catalog.cpp:1572
 #, c-format
 msgid "'%s' is not a valid POT file."
-msgstr "'%s' nėra tinkamas POT failas."
+msgstr "„%s“ nėra tinkamas POT failas."
 
 #: ../src/summarydlg.cpp:58
 #, c-format
@@ -260,7 +267,7 @@ msgstr "(0 naujų, 0 senų)"
 
 #: ../src/chooselang.cpp:79
 msgid "(Use default language)"
-msgstr "(Naudoti standartinę kalbą)"
+msgstr "(Naudoti numatytąją kalbą)"
 
 #: ../src/edframe.cpp:916
 msgid "(none of these)"
@@ -279,7 +286,7 @@ msgstr "<bevardis>"
 #. but don't add it to this translation yourself) (wxWidgets 2.8)
 #: ../src/edframe.cpp:2435
 msgid "About "
-msgstr "Apie"
+msgstr "Apie "
 
 #. TRANSLATORS: This is titlebar of about dialog, "%s" is application name
 #. ("Poedit" here, but please use "%s")
@@ -290,19 +297,19 @@ msgstr "Apie %s"
 
 #: ../src/resources/prefs.xrc:270
 msgid "Add"
-msgstr "Įtraukti"
+msgstr "Pridėti"
 
 #: ../src/resources/manager.xrc:91
 msgid "Add directory to the list"
-msgstr "%Įtraukti aplanką į sąrašą"
+msgstr "Į sąrašą pridėti aplanką"
 
 #: ../src/transmemupd_wizard.cpp:134 ../src/resources/tm_update.xrc:85
 msgid "Add files"
-msgstr "Įtraukti failus"
+msgstr "Pridėti failus"
 
 #: ../src/resources/prefs.xrc:589
 msgid "Add path to the list of directories where catalogs lie."
-msgstr "Įtraukti kelią į aplankų su vertimo failais sąrašą."
+msgstr "Pridėti kelią į aplankų su vertimo failais sąrašą."
 
 #: ../src/resources/prefs.xrc:111
 msgid "Always change focus to text input field"
@@ -342,7 +349,7 @@ msgstr "Išsaugojimo metu sukompiliuoti .mo failą"
 
 #: ../src/resources/prefs.xrc:342
 msgid "Automatically translate when updating catalog"
-msgstr "Iš karto versti atnaujinant katalogą"
+msgstr "Atnaujinant katalogą iš karto versti"
 
 #: ../src/edframe.cpp:2301
 #, c-format
@@ -359,7 +366,7 @@ msgstr "Netaisyklingi skirtukai"
 
 #: ../src/resources/properties.xrc:136
 msgid "Base path:"
-msgstr "Pagrindinis aplankas:"
+msgstr "Pagrindinis kelias:"
 
 #: ../src/resources/prefs.xrc:84
 msgid "Behavior"
@@ -368,15 +375,13 @@ msgstr "Elgsena"
 #: ../src/catalog.cpp:680
 msgid "Broken catalog file: plural form msgstr used without msgid_plural"
 msgstr ""
-"Sugadintas katalogo failas: pavartota daugiskaitinė msgstr forma, bet "
-"nenurodytas msgid_plural"
+"Sugadintas katalogo failas: daugiskaitos forma msgstr neturi msgid_plural"
 
 #: ../src/catalog.cpp:642
 msgid ""
 "Broken catalog file: singular form msgstr used together with msgid_plural"
 msgstr ""
-"Sugadintas katalogo failas: pavartota vienaskaitinė msgstr forma, tačiau "
-"nurodytas msgid_plural"
+"Sugadintas katalogo failas: vienaskaitos forma msgstr turi msgid_plural"
 
 #: ../src/resources/manager.xrc:90 ../src/resources/prefs.xrc:588
 #: ../src/resources/tm_update.xrc:37
@@ -388,9 +393,8 @@ msgid "C&atalog"
 msgstr "K&atalogas"
 
 #: ../src/resources/comment.xrc:45
-#, fuzzy
 msgid "C&lear"
-msgstr "Išvalyti"
+msgstr "Iš&valyti"
 
 #: ../src/resources/prefs.xrc:141
 msgid "CR/LF conversion"
@@ -401,25 +405,24 @@ msgstr "CR/LF keitimas"
 #: ../src/resources/prefs.xrc:611 ../src/resources/progress.xrc:32
 #: ../src/resources/properties.xrc:198
 msgid "Cancel"
-msgstr "Atšaukti"
+msgstr "Atsisakyti"
 
 #: ../src/transmem.cpp:732
-#, fuzzy
 msgid "Cannot create TM database directory!"
-msgstr "Negalima sukurti duomenų bazės aplanko!"
+msgstr "Sukurti VA duomenų bazės aplanko nepavyko!"
 
 #: ../src/utility.cpp:57 ../src/utility.cpp:67
 msgid "Cannot create temporary directory."
-msgstr "Nepavyko sukurti laikino aplanko."
+msgstr "Sukurti laikino aplanko nepavyko."
 
 #: ../src/gexecute.cpp:100
 #, c-format
 msgid "Cannot execute program: %s"
-msgstr "Negalima įvykdyti programos: %s"
+msgstr "Įvykdyti programos nepavyko: %s"
 
 #: ../src/transmemupd.cpp:199
 msgid "Cannot extract catalogs from RPM file."
-msgstr "Negalima išskirti katalogų iš RPM failo."
+msgstr "Išarchyvuoti katalogų iš RPM failo nepavyko."
 
 #: ../src/resources/find.xrc:36
 msgid "Case sensitive"
@@ -447,7 +450,7 @@ msgstr "Katalogų &tvarkyklė"
 
 #: ../src/resources/prefs.xrc:63
 msgid "Change UI language"
-msgstr "Pakeisti programos kalbą"
+msgstr "Keisti programos kalbą"
 
 #: ../src/export_html.cpp:119 ../src/resources/properties.xrc:74
 msgid "Charset:"
@@ -455,11 +458,11 @@ msgstr "Koduotė:"
 
 #: ../src/edframe.cpp:483
 msgid "Check for Updates..."
-msgstr ""
+msgstr "Tikrinti, ar yra atnaujinimų..."
 
 #: ../src/resources/toolbar.xrc:39
 msgid "Check for errors in the translation"
-msgstr ""
+msgstr "Tikrinti ar nėra vertimo klaidų"
 
 #: ../src/resources/prefs.xrc:204 ../src/resources/prefs.xrc:230
 msgid "Choose"
@@ -495,16 +498,15 @@ msgstr "Komentaras:"
 
 #: ../src/resources/prefs.xrc:292
 msgid "Configuration"
-msgstr "Parinktys"
+msgstr "Konfigūracija"
 
 #: ../src/manager.cpp:407 ../src/manager.cpp:427
 msgid "Confirmation"
 msgstr "Patvirtinimas"
 
 #: ../src/edframe.cpp:1812
-#, fuzzy
 msgid "Context:"
-msgstr "Išeities failas"
+msgstr "Kontekstas:"
 
 #: ../src/edframe.cpp:2332 ../src/resources/menus.xrc:59
 msgid "Copy from Source Text"
@@ -517,7 +519,7 @@ msgstr "Kopijuoti iš išeities tekstų"
 #: ../src/catalog.cpp:1038
 #, c-format
 msgid "Couldn't load file %s, it is probably corrupted."
-msgstr "Nepavyko įkrauti failo %s, jis greičiausiai sugadinta."
+msgstr "Nepavyko įkrauti failo %s, jis greičiausiai sugadintas."
 
 #: ../src/catalog.cpp:1307
 #, c-format
@@ -554,7 +556,7 @@ msgstr "Rodyti &eilučių numerius"
 
 #: ../src/resources/menus.xrc:170
 msgid "Display &Notes for Translators"
-msgstr ""
+msgstr "Rodyti &vertėjų pastabas"
 
 #: ../src/resources/menus.xrc:160
 msgid "Display &Quotes"
@@ -566,7 +568,7 @@ msgstr "Rodyti &eilučių numerius"
 
 #: ../src/resources/menus.xrc:169
 msgid "Display &notes for translators"
-msgstr ""
+msgstr "Rodyti &vertėjų pastabas"
 
 #: ../src/resources/menus.xrc:159
 msgid "Display &quotes"
@@ -610,7 +612,7 @@ msgstr "&Išeiti"
 
 #: ../src/resources/menus.xrc:39
 msgid "E&xport..."
-msgstr "&Iškelti..."
+msgstr "&Eksportuoti..."
 
 #: ../src/resources/manager.xrc:48 ../src/resources/prefs.xrc:383
 msgid "Edit"
@@ -625,9 +627,8 @@ msgid "Edit &comment"
 msgstr "&Keisti komentarą"
 
 #: ../src/edframe.cpp:2346
-#, fuzzy
 msgid "Edit Comment"
-msgstr "Keisti &komentarą"
+msgstr "Keisti komentarą"
 
 #: ../src/edframe.cpp:2344 ../src/resources/comment.xrc:4
 #: ../src/resources/toolbar.xrc:58
@@ -652,7 +653,7 @@ msgstr "Redaktorius"
 
 #: ../src/resources/prefs.xrc:129
 msgid "Enables on-the-fly spellchecking"
-msgstr "Įjungia rašybos tikrintuvą"
+msgstr "Įjungia rašybos tikrinimą"
 
 #: ../src/edframe.cpp:1309
 msgid "Entries in the catalog are probably incorrect."
@@ -663,17 +664,21 @@ msgid ""
 "Entries in this catalog have different plural forms count from what "
 "catalog's Plural-Forms header says"
 msgstr ""
+"Šio katalogo daugiskaitos formų įrašų ne tiek kiek jų nurodo „Plurar-Forms“ "
+"antraštė"
 
 #: ../src/edframe.cpp:1376
 msgid ""
 "Entries with errors were marked in red in the list. Details of the error "
 "will be shown when you select such an entry."
 msgstr ""
+"Įrašai su klaidom pažymėti raudonai. Išsamiau apie klaidą bus parodyta "
+"pasirinkus įrašą."
 
 #: ../src/edframe.cpp:1960
-#, fuzzy, c-format
+#, c-format
 msgid "Error loading message catalog file '%s'."
-msgstr "Klaida įkraunant pranešimų katalogo failą '"
+msgstr "Klaida įkeliant katalogo failą „%s“."
 
 #: ../src/fileviewer.cpp:226
 #, c-format
@@ -686,40 +691,38 @@ msgstr "Klaida išsaugant katalogą"
 
 #: ../src/errorbar.cpp:60
 msgid "Error:"
-msgstr ""
+msgstr "Klaida:"
 
 #: ../src/edframe.cpp:1138
 msgid "Export as..."
-msgstr "Išsaugot &kaip..."
+msgstr "Eksportuoti kaip..."
 
 #: ../src/resources/properties.xrc:127
 msgid "Extract text from source files in the following directories:"
-msgstr ""
+msgstr "Eksportuoti tekstą iš išeities failų esančių šiuose aplankaluose:"
 
 #: ../src/digger.cpp:60
-#, fuzzy, c-format
+#, c-format
 msgid "Failed command: %s"
-msgstr "Sintaksinio analizatoriaus komanda:"
+msgstr "Nepavykus komanda: %s"
 
 #: ../src/digger.cpp:114
-#, fuzzy
 msgid "Failed to load extracted catalog."
-msgstr "'%s' nėra pranešimų katalogo failas."
+msgstr "Nepavyko įkelti ištrauktų katalogų"
 
 #: ../src/digger.cpp:61
-#, fuzzy
 msgid "Failed to merge gettext catalogs."
-msgstr "'%s' nėra pranešimų katalogo failas."
+msgstr "Sujungti gettext katalogų nepavyko."
 
 #: ../src/edframe.cpp:393 ../src/edframe.cpp:1061
 #, c-format
 msgid "File '%s' doesn't exist."
-msgstr "Failo '%s' nėra."
+msgstr "Failo „%s“ nėra."
 
 #: ../src/edframe.cpp:386
-#, fuzzy, c-format
+#, c-format
 msgid "File '%s' is not a message catalog."
-msgstr "'%s' nėra pranešimų katalogo failas."
+msgstr "„%s“ nėra pranešimų katalogo failas."
 
 #: ../src/catalog.cpp:1268
 #, c-format
@@ -727,7 +730,7 @@ msgid ""
 "File '%s' is read-only and cannot be saved.\n"
 "Please save it under different name."
 msgstr ""
-"Failas '%s' skirtas tik skaitymui ir negali būti išsaugotas.\n"
+"Failas „%s“ skirtas tik skaitymui ir negali būti išsaugotas.\n"
 "Išsaugokite duomenis kitu vardu."
 
 #: ../src/transmemupd_wizard.cpp:59
@@ -770,7 +773,7 @@ msgstr "Forma %i"
 #: ../src/edframe.cpp:2721
 #, c-format
 msgid "Form %i (e.g. \"%u\")"
-msgstr "Forma %i (pvz., \"%u\")"
+msgstr "Forma %i (pvz., „%u“)"
 
 #: ../src/manager.cpp:247 ../src/resources/toolbar.xrc:51
 msgid "Fuzzy"
@@ -778,7 +781,7 @@ msgstr "Neaiškus"
 
 #: ../src/export_html.cpp:179
 msgid "Fuzzy translation"
-msgstr "&Neaiškus vertimas"
+msgstr "Neaiškus vertimas"
 
 #: ../src/edframe.cpp:1043 ../src/edframe.cpp:1102
 msgid "GNU gettext catalogs (*.po)|*.po|All files (*.*)|*.*"
@@ -790,26 +793,26 @@ msgstr "GNU gettext šablonai (*.pot)|*.pot|Visi failai (*.*)|*.*"
 
 #: ../src/resources/prefs.xrc:621
 msgid "Generate TM database"
-msgstr "Formuoti TM duomenų bazę"
+msgstr "Kurti VA duomenų bazę"
 
 #: ../src/resources/prefs.xrc:278
 msgid "Generate database"
-msgstr "Formuoti duomenų bazę"
+msgstr "Kurti duomenų bazę"
 
 #: ../src/edframe.cpp:2798
-#, fuzzy, c-format
+#, c-format
 msgid "Go to Bookmark %i\tCtrl+%i"
-msgstr "Eiti į žymelę %i\tVald-%i"
+msgstr "Eiti į žymelę %i\tCtrl+%i"
 
 #: ../src/edframe.cpp:2792
-#, fuzzy, c-format
+#, c-format
 msgid "Go to Bookmark %i\tCtrl+Alt+%i"
-msgstr "Eiti į žymelę %i\tVald-%i"
+msgstr "Eiti į žymelę %i\tCtrl+Alt+%i"
 
 #: ../src/edframe.cpp:2795
-#, fuzzy, c-format
+#, c-format
 msgid "Go to bookmark %i\tCtrl+%i"
-msgstr "Eiti į žymelę %i\tVald-%i"
+msgstr "Eiti į žymelę %i\tCtrl+%i"
 
 #: ../src/edframe.cpp:1140
 msgid "HTML file (*.html)|*.html"
@@ -821,22 +824,20 @@ msgstr "Slėpti šį perspėjimą"
 
 #: ../src/resources/prefs.xrc:18
 msgid "Identity"
-msgstr "Tapatumas"
+msgstr "Tapatybė"
 
 #: ../src/resources/prefs.xrc:121
 msgid "If checked, the comment window will be editable."
 msgstr "Jeigu pažymėta, galima redaguoti komentarų langą."
 
 #: ../src/edframe.cpp:2229
-#, fuzzy
 msgid ""
 "If you continue with purging, all translations marked as deleted will be "
 "permanently removed. You will have to translate them again if they are added "
 "back in the future."
 msgstr ""
-"Ar tikrai norite išmesti visus vertimus iš katalogo, kurie nebenaudojami?\n"
-"Jei nuspręsite tęsti, teks išversti iš naujo, jei tie patys vertimai bus vėl "
-"pridėti vėliau."
+"Jei tęsite šalinimą, visi vertimai pažymėti kaip „pašalinta“ bus visam "
+"laikui pašalinti. Jei ateityje jie bus pridėti turėsite juos versti iš naujo."
 
 #: ../src/resources/prefs.xrc:472
 msgid "Invocation:"
@@ -844,7 +845,7 @@ msgstr "Iškvietimas:"
 
 #: ../src/edframe.cpp:2234 ../src/transmem.cpp:1202
 msgid "Keep"
-msgstr ""
+msgstr "Palikti"
 
 #: ../src/propertiesdlg.cpp:58
 msgid "Keywords"
@@ -865,7 +866,7 @@ msgstr "Paskutinis pakeitimas"
 
 #: ../src/resources/properties.xrc:111
 msgid "Learn about plural forms"
-msgstr ""
+msgstr "Sužinkokite apie daugiskaitos formas"
 
 #: ../src/edframe.cpp:889
 msgid "Learn more"
@@ -878,7 +879,7 @@ msgstr "Eilutė"
 #: ../src/catalog.cpp:145
 #, c-format
 msgid "Line %u of file '%s' is corrupted (not valid %s data)."
-msgstr "Eilutė %u iš failo '%s' sugadinta (netaisyklingi %s duomenys)."
+msgstr "Eilutė %u iš failo „%s“ sugadinta (netinkami %s duomenys)."
 
 #: ../src/resources/prefs.xrc:149
 msgid "Line endings format:"
@@ -891,7 +892,7 @@ msgstr "Plėtinių, atskirtų kabliataškiais, sąrašas (pvz., *.cpp;*.h):"
 #: ../src/catalog.cpp:220
 #, c-format
 msgid "Malformed header: '%s'"
-msgstr "Netaisyklinga antraštė: '%s'"
+msgstr "Netinkama antraštė: „%s“"
 
 #: ../src/resources/prefs.xrc:300
 msgid "Max. # of missing words:"
@@ -919,11 +920,11 @@ msgstr "Mano kalbos"
 
 #: ../src/resources/menus.xrc:152
 msgid "Ne&xt Unfinished"
-msgstr ""
+msgstr "&Kitas nebaigtas"
 
 #: ../src/resources/menus.xrc:151
 msgid "Ne&xt unfinished"
-msgstr ""
+msgstr "&Kitas nebaigtas"
 
 #: ../src/resources/prefs.xrc:113
 msgid ""
@@ -961,12 +962,11 @@ msgstr "Kitas >"
 
 #: ../src/digger.cpp:201
 msgid "No files found in: "
-msgstr "Nėra failų: "
+msgstr "Failų nerasta: "
 
 #: ../src/edframe.cpp:1391
-#, fuzzy
 msgid "No problems with the translation found."
-msgstr "Nėra nuorodų į šias eilutes."
+msgstr "Nerasta vertimo klaidų."
 
 #: ../src/edframe.cpp:1433
 msgid "No references to this string found."
@@ -977,9 +977,8 @@ msgid "Notes"
 msgstr "Pastabos"
 
 #: ../src/edframe.cpp:550
-#, fuzzy
 msgid "Notes for translators:"
-msgstr "Automatiniai vertimai:"
+msgstr "Pastabos vertėjams:"
 
 #: ../src/resources/comment.xrc:30 ../src/resources/manager.xrc:105
 #: ../src/resources/prefs.xrc:416 ../src/resources/prefs.xrc:558
@@ -1006,32 +1005,32 @@ msgstr "Atverti katalogo šabloną"
 
 #: ../src/resources/prefs.xrc:104
 msgid "Open catalogs manager on Poedit startup"
-msgstr "Startuojant Poedit, atverti katalogų tvarkyklę"
+msgstr "Paleidžiant Poedit, atverti katalogų tvarkyklę"
 
 #: ../src/resources/menus.xrc:147
 msgid "P&revious Unfinished"
-msgstr ""
+msgstr "&Ankstesnis nebaigtas"
 
 #: ../src/resources/menus.xrc:146
 msgid "P&revious unfinished"
-msgstr ""
+msgstr "&Ankstesnis nebaigtas"
 
 #: ../src/resources/prefs.xrc:476
 msgid "Parser command:"
-msgstr "Sintaksinio analizatoriaus komanda:"
+msgstr "Apdorojimo komanda:"
 
 #: ../src/resources/prefs.xrc:435
 msgid "Parser setup"
-msgstr "Sintaksinio analizatoriaus suderinimas"
+msgstr "Apdorojimo nustatymas"
 
 #: ../src/resources/prefs.xrc:353
 msgid "Parsers"
-msgstr "Sintaksiniai analizatoriai"
+msgstr "Apdorokliai"
 
 #: ../src/digger.cpp:92
-#, fuzzy, c-format
+#, c-format
 msgid "Parsing %s files..."
-msgstr "Peržiūrimi failai..."
+msgstr "Apdorojami %s failai..."
 
 #: ../src/propertiesdlg.cpp:60
 msgid "Paths"
@@ -1039,7 +1038,7 @@ msgstr "Keliai"
 
 #: ../src/resources/prefs.xrc:12
 msgid "Personalize"
-msgstr "Prisitaikykite"
+msgstr "Suasmeninti"
 
 #: ../src/resources/prefs.xrc:271
 msgid "Pick language from the list of known languages"
@@ -1070,6 +1069,11 @@ msgid ""
 "Old location: %s\n"
 "New location: %s"
 msgstr ""
+"Patvirtinkite jog visi failai buvo perkelti į naują vietą arba perkelkite "
+"juos rankiniu būdu.\n"
+"\n"
+"Sena vieta: %s\n"
+"Nauja vieta: %s"
 
 #: ../src/resources/properties.xrc:98
 msgid "Plural Forms:"
@@ -1096,9 +1100,8 @@ msgid "Poedit is an easy to use translations editor."
 msgstr "Poedit yra lengvai naudojamas vertimų redaktorius."
 
 #: ../src/transmem.cpp:1191
-#, fuzzy
 msgid "Poedit translation memory error"
-msgstr "Atnaujinti vertimo atmintį"
+msgstr "Poedit vertimų atminties klaida"
 
 #: ../src/resources/prefs.xrc:4
 msgid "Preferences"
@@ -1122,7 +1125,7 @@ msgstr "Projekto pavadinimas:"
 
 #: ../src/edframe.cpp:2234 ../src/transmem.cpp:1202
 msgid "Purge"
-msgstr ""
+msgstr "Išvalyti"
 
 #: ../src/edframe.cpp:2225
 msgid "Purge deleted translations"
@@ -1130,7 +1133,7 @@ msgstr "Pašalinti ištrintus vertimus"
 
 #: ../src/resources/manager.xrc:137 ../src/resources/menus.xrc:52
 msgid "Quit"
-msgstr "Išjungti"
+msgstr "Baigti darbą"
 
 #: ../src/edframe.cpp:1441
 msgid "References"
@@ -1143,16 +1146,16 @@ msgstr "Nuorodos:"
 #: ../src/resources/prefs.xrc:279
 msgid "Regenerate translation memory from catalogs in paths listed above."
 msgstr ""
-"Performuoti vertimo atmintį iš katalogų, esančių aukščiau išvardintuose "
+"Sukurti vertimo atmintį iš katalogų, esančių aukščiau išvardintuose "
 "aplankuose."
 
 #: ../src/edframe.cpp:1922
 msgid "Required header Plural-Forms is missing."
-msgstr ""
+msgstr "Trūksta būtinos „Plurar-Forms“ antraštės."
 
 #: ../src/resources/tm_update.xrc:42
 msgid "Reset to defaults"
-msgstr "Atstatyti standartines reikšmes"
+msgstr "Atstatyti numatytuosius"
 
 #: ../src/edframe.cpp:995 ../src/resources/toolbar.xrc:25
 #: ../src/resources/toolbar.xrc:30
@@ -1208,29 +1211,23 @@ msgid "Select your prefered language"
 msgstr "Pasirinkite pagrindinę kalbą"
 
 #: ../src/edframe.cpp:2797
-#, fuzzy, c-format
+#, c-format
 msgid "Set Bookmark %i\tAlt+%i"
-msgstr ""
-"Nustatyti žymelę %i\n"
-"Lyg2-%i"
+msgstr "Nustatyti žymelę %i\tAlt+%i"
 
 #: ../src/edframe.cpp:2791
-#, fuzzy, c-format
+#, c-format
 msgid "Set Bookmark %i\tCtrl+%i"
-msgstr ""
-"Nustatyti žymelę %i\n"
-"Lyg2-%i"
+msgstr "Nustatyti žymelę %i\tCtrl+%i"
 
 #: ../src/edframe.cpp:2794
-#, fuzzy, c-format
+#, c-format
 msgid "Set bookmark %i\tAlt+%i"
-msgstr ""
-"Nustatyti žymelę %i\n"
-"Lyg2-%i"
+msgstr "Nustatyti žymelę %i\tAlt+%i"
 
 #: ../src/edframe.cpp:1893
 msgid "Set email"
-msgstr "Nustatyti e. paštą"
+msgstr "Nustatyti el. paštą"
 
 #: ../src/resources/prefs.xrc:97
 msgid "Show summary after catalog update"
@@ -1242,11 +1239,11 @@ msgstr "Vienaskaita:"
 
 #: ../src/resources/menus.xrc:182
 msgid "Sort by &File Order"
-msgstr ""
+msgstr "Rikiuoti pagal &Failų eilę"
 
 #: ../src/resources/menus.xrc:187
 msgid "Sort by &Source"
-msgstr ""
+msgstr "Rikiuoti pagal &Šaltinį"
 
 #: ../src/resources/menus.xrc:192
 msgid "Sort by &Translation"
@@ -1254,11 +1251,11 @@ msgstr "Rikiuoti pagal &vertimą"
 
 #: ../src/resources/menus.xrc:181
 msgid "Sort by &file order"
-msgstr ""
+msgstr "Rikiuoti pagal &failų eilę"
 
 #: ../src/resources/menus.xrc:186
 msgid "Sort by &source"
-msgstr ""
+msgstr "Rikiuoti pagal &šaltinį"
 
 #: ../src/resources/menus.xrc:191
 msgid "Sort by &translation"
@@ -1281,35 +1278,31 @@ msgid "Source file"
 msgstr "Išeities failas"
 
 #: ../src/fileviewer.cpp:61
-#, fuzzy
 msgid "Source file occurrence:"
-msgstr "Išeities failas"
+msgstr "Išeities failas pasikartojimai:"
 
 #: ../src/edlistctrl.cpp:325
-#, fuzzy
 msgid "Source text"
-msgstr "Išeities failas"
+msgstr "Išeities tekstas"
 
 #: ../src/edframe.cpp:536
-#, fuzzy
 msgid "Source text:"
-msgstr "Išeities failas"
+msgstr "Išeities tekstas:"
 
 #: ../src/resources/properties.xrc:179
 msgid "Sources keywords"
-msgstr ""
+msgstr "Išeities failų raktažodžiai"
 
 #: ../src/resources/properties.xrc:158
-#, fuzzy
 msgid "Sources paths"
-msgstr "Paieškos keliai"
+msgstr "Išeities failų keliai"
 
 #. TRANSLATORS: %s is language name in its basic form (as you
 #. would see e.g. in a list of supported languages).
 #: ../src/edframe.cpp:885
 #, c-format
 msgid "Spellchecker dictionary for %s isn't available, you need to install it."
-msgstr ""
+msgstr "Rašybos tikrinimas %s kalbai neprieinamas, jums reikia jį įdiegti."
 
 #: ../src/resources/find.xrc:43
 msgid "Start from the first item"
@@ -1322,7 +1315,7 @@ msgstr "Ieškoma eilutė:"
 #: ../src/edframe.cpp:1927
 #, c-format
 msgid "Syntax error in Plural-Forms header (\"%s\")."
-msgstr ""
+msgstr "Sintaksės klaida Plural-Forms antraštėje („%s“)."
 
 #: ../src/export_html.cpp:115 ../src/resources/properties.xrc:48
 msgid "Team's email address:"
@@ -1339,8 +1332,8 @@ msgid ""
 "specified in catalog settings. It was saved in UTF-8 instead\n"
 "and the setting was modified accordingly."
 msgstr ""
-"Katalogas negalėjo būti išsaugotas '%s' koduote\n"
-"kaip nurodyta sąrašo nustatuose. Jis išsaugotas UTF-8 koduote\n"
+"Katalogas negalėjo būti išsaugotas „%s“ koduote\n"
+"kaip nurodyta sąrašo nustatymuose. Jis išsaugotas UTF-8 koduote\n"
 "ir atitinkamai pakeisti nustatymai."
 
 #: ../src/edframe.cpp:1380
@@ -1348,20 +1341,21 @@ msgid ""
 "The file was saved safely, but it cannot be compiled into the MO format and "
 "used."
 msgstr ""
+"Failas saugiai išsaugotas, bet jo neįmanoma sukompiliuoti į MO formatą ir "
+"naudoti."
 
 #: ../src/edframe.cpp:1396
-#, fuzzy
 msgid "The translation is ready for use."
-msgstr "&Neaiškus vertimas"
+msgstr "Vertimas paruoštas naudoti."
 
 #: ../src/catalog.cpp:1311
 msgid ""
 "There was a problem formatting the file nicely (but it was saved all right)."
-msgstr ""
+msgstr "Kilo bėdų gražiai formatuojant failą (bet jis buvo išsaugotas)."
 
 #: ../src/transmem.cpp:1193
 msgid "There was a problem moving your translation memory."
-msgstr ""
+msgstr "Kilo bėdų perkeliant jūsų vertimų atminty."
 
 #: ../src/catalog.cpp:1030
 msgid ""
@@ -1392,6 +1386,8 @@ msgid ""
 "This catalog has entries with plural forms, but doesn't have Plural-Forms "
 "header configured."
 msgstr ""
+"Šio katalogo įrašai su daugiskaitos formomis, bet neturi sukonfigūruotos "
+"Plurar-Forms antraštės."
 
 #: ../src/resources/prefs.xrc:488
 msgid ""
@@ -1464,9 +1460,9 @@ msgid "Translation is &fuzzy"
 msgstr "&Neaiškus vertimas"
 
 #: ../src/transmem.cpp:661
-#, fuzzy, c-format
+#, c-format
 msgid "Translation memory database error: %s"
-msgstr "Duomenų bazės klaida: %s"
+msgstr "Vertimų atminties duomenų bazės klaida: %s"
 
 #: ../src/resources/tm_update.xrc:68
 msgid ""
@@ -1499,7 +1495,7 @@ msgstr "Unix (rekomenduojama)"
 #: ../src/chooselang.cpp:60
 #, c-format
 msgid "Unknown locale code '%s' in registry."
-msgstr "Nežinomas lokalės kodas '%s' registre."
+msgstr "Nežinomas lokalės kodas „%s“ registre."
 
 #: ../src/manager.cpp:246
 msgid "Untrans"
@@ -1538,21 +1534,18 @@ msgid "Update translation memory"
 msgstr "Atnaujinti vertimo atmintį"
 
 #: ../src/edframe.cpp:1297 ../src/manager.cpp:435
-#, fuzzy
 msgid "Updating catalog"
-msgstr "Atnaujinamas katalogas..."
+msgstr "Atnaujinamas katalogas"
 
 #: ../src/edframe.cpp:1311
-#, fuzzy
 msgid "Updating the catalog failed. Click on 'Details >>' for details."
 msgstr ""
-"Katalogo atnaujinimas nepavyko. Norėdami sužinoti daugiau, spausk 'Daugiau "
-">>'."
+"Katalogo atnaujinimas nepavyko. Norėdami sužinoti daugiau, spauskite "
+"„Daugiau >>“."
 
 #: ../src/transmemupd_wizard.cpp:194
-#, fuzzy
 msgid "Updating translation memory"
-msgstr "Atnaujinti vertimo atmintį"
+msgstr "Atnaujinama vertimo atmintis"
 
 #: ../src/resources/prefs.xrc:213
 msgid "Use custom font for text fields"
@@ -1563,22 +1556,20 @@ msgid "Use custom font for translations list"
 msgstr "Naudoti nurodytą šriftą vertimų sąrašui"
 
 #: ../src/resources/properties.xrc:166
-#, fuzzy
 msgid ""
 "Use these keywords (function names) to recognize translatable strings\n"
 "in source files:"
 msgstr ""
 "Be standartinių, naudokite šiuos raktažodžius (funkcijų pavadinimus),\n"
-"verstinų išeities tekstuose eilučių atpažinimui."
+"verstinų išeities tekstuose eilučių atpažinimui:"
 
 #: ../src/resources/toolbar.xrc:38
 msgid "Validate"
-msgstr ""
+msgstr "Patvirtinti"
 
 #: ../src/edframe.cpp:1372 ../src/edframe.cpp:1392
-#, fuzzy
 msgid "Validation results"
-msgstr "Vertimo savybės"
+msgstr "Patvirtinimo rezultatai"
 
 #. TRANSLATORS: This is version information in about dialog, "%s" will be
 #. version number when used
@@ -1589,7 +1580,7 @@ msgstr "Versija %s"
 
 #: ../src/resources/prefs.xrc:255
 msgid "What languages do you want to use the TM with?"
-msgstr ""
+msgstr "Su kuriomis kalbomis norite naudoti VA?"
 
 #: ../src/resources/find.xrc:50
 msgid "Whole words only"
@@ -1601,66 +1592,40 @@ msgstr "Windows"
 
 #: ../src/edframe.cpp:378
 msgid "You can't drop more than one file on Poedit window."
-msgstr "Negalite užvilkti daugiau nei vienos failo ant Poedit lango."
+msgstr "Negalite užvilkti daugiau nei vieno failo ant Poedit lango."
 
 #: ../src/chooselang.cpp:173
 msgid "You must restart Poedit for this change to take effect."
-msgstr "Kad pakeitimai pradėtų veikti, turite iš naujo paleisti Poedit."
+msgstr "Šis pakeitimas įsigalios paleidus Poedit iš naujo."
 
 #: ../src/edframe.cpp:1891
 msgid ""
 "You should set your email address in Preferences so that it can be used for "
 "Last-Translator header in GNU gettext files."
 msgstr ""
+"Nustatymuose turite nurodyti savo el. pašto adresą, kad jį būtų galima "
+"naudoti Last-Translator antraštėje."
 
 #: ../src/edframe.cpp:992
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Jūsų pakeitimai bus prarasti, jei jų neišsaugosite."
 
 #: ../src/resources/prefs.xrc:44
 msgid "Your email address:"
-msgstr "Jūsų e. pašto adresas:"
+msgstr "Jūsų el. pašto adresas:"
 
 #: ../src/resources/prefs.xrc:22
 msgid ""
 "Your name and email set below are only used\n"
 "to set the Last-Translator header of GNU gettext files."
 msgstr ""
+"Jūsų el. pašto adresas ir vardas naudojamai tik\n"
+"Last-Translator antraštės sukūrimui."
 
 #: ../src/resources/prefs.xrc:30
 msgid "Your name:"
-msgstr "Vardas, pavardė:"
+msgstr "Jūsų vardas:"
 
 #: ../src/edapp.cpp:372
 msgid "don't delete temporary files (for debugging)"
 msgstr "netrinti laikinų failų (derinimui)"
-
-#~ msgid "Automatic C&omments Window"
-#~ msgstr "Automatinių k&omentarų langas"
-
-#~ msgid "Automatic c&omments window"
-#~ msgstr "Automatinių k&omentarų langas"
-
-#~ msgid "Automatic comments:"
-#~ msgstr "Automatiniai komentarai:"
-
-#~ msgid "Cannot execute program: "
-#~ msgstr "Negalima įvykdyti programos: "
-
-#~ msgid "Country:"
-#~ msgstr "Šalis:"
-
-#~ msgid "Gettext syntax error"
-#~ msgstr "Gettext sintaksės klaida"
-
-#, fuzzy
-#~ msgid "[checking translations: %i left]"
-#~ msgid_plural "[checking translations: %i left]"
-#~ msgstr[0] "[tikrinami vertimai: liko %i]"
-#~ msgstr[1] "[tikrinami vertimai: liko %i]"
-
-#~ msgid "Copy Translation from Source Text"
-#~ msgstr "Kopijuoti vertimus iš išeities tekstų"
-
-#~ msgid "Copy translation from source text"
-#~ msgstr "Kopijuoti vertimus iš išeities tekstų"


### PR DESCRIPTION
Template is obsolete, eg. then you first time launch app you see dialog from file edapp.cpp:
"A lot of time and effort have gone into development
of Poedit. If it's useful to you, please consider showing
your appreciation with a donation.
Donate or not, there will be no difference in Poedit's
features and functionality."
in template there is no that string and few more are missing. 
P.S. i didn't understand how you create .pot... tried to generate with poedit and got a lot of errors, tried generate with "intltool-update -p" got template with 3000+ strings, not with 354 like yours, so i updated existing template.
