### PR TITLE
Add keywords to desktop file

### DIFF
--- a/poedit.desktop
+++ b/poedit.desktop
@@ -29,3 +29,4 @@ Terminal=false
 Type=Application
 Categories=Development;Translation;
 StartupNotify=true
+Keywords=Translate;po;gettext;


### PR DESCRIPTION
Adds keywords entry to the desktop file, fixes lintian warning desktop-entry-lacks-keywords-entry. Closes trac Ticket #540.
