### PR TITLE
Fix Catalog::SetValidity() API strangeness

### DIFF
--- a/src/catalog.h
+++ b/src/catalog.h
@@ -260,8 +260,7 @@ class CatalogItem
         /** Checks if %i etc. are correct in the translation (true if yes).
             Strings that are not c-format are always correct. */
         Validity GetValidity() const { return m_validity; }
-        void SetValidity(bool val)
-            { m_validity = val ? Val_Valid : Val_Invalid; }
+        void SetValidity(Validity val) { m_validity = val; }
 
         void SetErrorString(const wxString& str) { m_errorString = str; }
         wxString GetErrorString() const { return m_errorString; }


### PR DESCRIPTION
SetValidity() should probably not take a bool, as it is always called with a Validity argument.
