### PR TITLE
Proof of concept X-Poedit-Potfile header

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -396,6 +396,7 @@ void Catalog::HeaderData::ParseDict()
     // Parse extended information:
     SourceCodeCharset = GetHeader("X-Poedit-SourceCharset");
     BasePath = GetHeader("X-Poedit-Basepath");
+    PotFile = GetHeader("X-Poedit-Potfile");
 
     Keywords.Clear();
     wxString kwlist = GetHeader("X-Poedit-KeywordsList");
@@ -955,6 +956,8 @@ Catalog::Catalog()
 {
     m_isOk = true;
     m_header.BasePath = wxEmptyString;
+    m_header.PotFile = wxEmptyString;
+
     for(int i = BOOKMARK_0; i < BOOKMARK_LAST; i++)
     {
         m_header.Bookmarks[i] = -1;
@@ -1675,6 +1678,16 @@ bool Catalog::Update(ProgressInfo *progress, bool summary, bool *cancelledByUser
             wxLogError(_("Source code directory '%s' doesn't exist."), path.c_str());
             return false;
         }
+
+        wxString pot_file = m_header.PotFile;
+        if (!pot_file.empty())
+        {
+            if (!wxIsAbsolutePath(pot_file))
+                pot_file = path + "/" + pot_file;
+    
+            return UpdateFromPOT(pot_file, summary, cancelledByUser);
+        }
+
 
         wxSetWorkingDirectory(path);
     }

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -456,6 +456,7 @@ class Catalog
             wxArrayString SearchPaths, Keywords;
             int Bookmarks[BOOKMARK_LAST];
             wxString BasePath;
+            wxString PotFile;
 
             wxString Comment;
 

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -2668,7 +2668,7 @@ void PoeditFrame::UpdateMenu()
                     editable && m_catalog->HasDeletedItems());
 
     const bool doupdate = hasCatalog &&
-                          !m_catalog->Header().SearchPaths.empty();
+                          (!m_catalog->Header().SearchPaths.empty() || !m_catalog->Header().PotFile.empty());
     toolbar->EnableTool(XRCID("menu_update"), doupdate);
     menubar->Enable(XRCID("menu_update"), doupdate);
 


### PR DESCRIPTION
Hello,

When using Poedit, I usually have projects with pot files.

With the "Update from POT File" I always have to navigate to the pot file (which is always in the same location for a project).

I decided I'd try a proof-of-concept X-Poedit-Potfile header storing the location of the pot file. See changes (I do not regularly program C...)

I've only tested this on MacOS X with a relative path (and no BaseDir set).

What's your opinion?
