### PR TITLE
Issue #112 make legacy tm optional

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Patches:
   Marcin Floryan <mfloryan@users.sourceforge.net>
   Stanislav Petrakov <stannic@gmail.com>
   Byrial Jensen <byrial@vip.cybercity.dk>
+  Andreas Stieger <andreas.stieger@gmx.de>
 
 Translations:
   Traditional Chinese:    Leo Liaw <leo@mis.ccu.edu.tw> 

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,11 @@ AC_ARG_ENABLE(debug,
               AS_HELP_STRING([--enable-debug],
                              [Enable debug build]),
               USE_DEBUG="$enableval", USE_DEBUG="no")
+AC_ARG_ENABLE(legacy-tm,
+              AS_HELP_STRING([--enable-legacy-tm],
+                             [Enable support for conversion of legacy translation memory format (default: yes)]),
+              USE_LEGACY_TM="$enableval", USE_LEGACY_TM="yes") 
+AM_CONDITIONAL([USE_LEGACY_TM], [test "x$USE_LEGACY_TM" = xyes])
 
 AC_MSG_CHECKING(for install location)
 case "$prefix" in
@@ -149,13 +154,16 @@ PKG_CHECK_MODULES([GTKSPELL], [$gtkspell_packages],
     ])
 
 
-AX_BERKELEY_DB_CXX(4.7,
-[
-    AC_DEFINE_UNQUOTED(DB_HEADER, ["$DB_HEADER"])
-    AC_SUBST(DB_LIBS)
-],
-[
-  AC_MSG_ERROR([cannot find required Berkeley DB >= 4.7])
+AS_IF([test "x$USE_LEGACY_TM" != "xno"], [
+    AX_BERKELEY_DB_CXX(4.7,
+    [
+        AC_DEFINE_UNQUOTED(DB_HEADER, ["$DB_HEADER"])
+        AC_SUBST(DB_LIBS)
+        AC_DEFINE(USE_LEGACY_TM)
+    ],
+    [
+      AC_MSG_ERROR([cannot find required Berkeley DB >= 4.7])
+    ])
 ])
 
 PKG_CHECK_MODULES([LUCENE], [liblucene++ >= 3.0.5],
@@ -212,5 +220,6 @@ AC_OUTPUT
 echo "
 Configured $PACKAGE-$VERSION for $host
 
-    Debug build:      $USE_DEBUG
+    Debug build:       $USE_DEBUG
+    Legacy TM support: $USE_LEGACY_TM
 "

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,9 @@ WX_LIBS = @WX_LIBS@
 RC_WX_INCLUDES = @RC_WX_INCLUDES@
 
 bin_PROGRAMS = poedit
+if USE_LEGACY_TM
 libexec_PROGRAMS = poedit-dump-legacy-tm
+endif
 
 poedit_SOURCES = attentionbar.cpp attentionbar.h \
                  errorbar.cpp errorbar.h \
@@ -18,7 +20,7 @@ poedit_SOURCES = attentionbar.cpp attentionbar.h \
                  gexecute.cpp summarydlg.h summarydlg.cpp \
                  spellchecking.h spellchecking.cpp \
                  findframe.cpp findframe.h commentdlg.h commentdlg.cpp \
-                 tm/suggestions.cpp tm/suggestions.h tm/transmem.cpp tm/transmem.h tm/tm_migrate.cpp \
+                 tm/suggestions.cpp tm/suggestions.h tm/transmem.cpp tm/transmem.h \
                  tm/ThreadPool.h \
                  manager.h manager.cpp chooselang.cpp chooselang.h \
                  export_html.cpp icons.h icons.cpp \
@@ -28,19 +30,24 @@ poedit_SOURCES = attentionbar.cpp attentionbar.h \
                  utility.cpp utility.h \
                  version.h errors.h \
                  icuhelpers.h logcapture.h \
-                 language.cpp language.h language_impl_legacy.h language_impl_plurals.h \
+                 language.cpp language.h language_impl_plurals.h \
                  languagectrl.cpp languagectrl.h \
                  welcomescreen.cpp welcomescreen.h \
                  syntaxhighlighter.cpp syntaxhighlighter.h \
                  sidebar.cpp sidebar.h \
                  customcontrols.cpp customcontrols.h
+if USE_LEGACY_TM
+poedit_SOURCES += language_impl_legacy.h tm/tm_migrate.cpp
+endif
 nodist_poedit_SOURCES = compiled_xrc.cpp
 
 poedit_LDADD = $(RESOURCE_FILES) $(WX_LIBS) $(LUCENE_LIBS) $(EXPAT_LIBS) \
                -lboost_regex -lboost_system
 
+if USE_LEGACY_TM
 poedit_dump_legacy_tm_SOURCES = tm/dump_legacy_tm.cpp
 poedit_dump_legacy_tm_LDADD = $(DB_LIBS)
+endif
 
 XRC_RESOURCES = \
 		$(srcdir)/resources/menus.xrc \

--- a/src/edapp.cpp
+++ b/src/edapp.cpp
@@ -85,7 +85,9 @@ struct PoeditApp::RecentMenuData
 };
 #endif
 
+#ifdef USE_LEGACY_TM
 extern bool MigrateLegacyTranslationMemory();
+#endif // USE_LEGACY_TM
 
 IMPLEMENT_APP(PoeditApp);
 
@@ -243,9 +245,11 @@ bool PoeditApp::OnInit()
     FileHistory().Load(*wxConfig::Get());
 #endif
 
+    #ifdef USE_LEGACY_TM
     // NB: It's important to do this before TM is used for the first time.
     if ( !MigrateLegacyTranslationMemory() )
         return false;
+    #endif // USE_LEGACY_TM
 
 #ifdef __WXMSW__
     AssociateFileTypeIfNeeded();


### PR DESCRIPTION
This implements the autotools part of making legacy translation memory (berkeley db) optional from issue #112 
