### PR TITLE
Add silk optional license

### DIFF
--- a/artwork/README
+++ b/artwork/README
@@ -13,3 +13,10 @@ Status icons are from Mark James's Silk icons set
 [http://www.famfamfam.com/lab/icons/silk] and are under the
 Creative Commons Attribution 2.5 License
 [http://creativecommons.org/licenses/by/2.5/].
+The Silk icons can also be used under Creative Commons Attribution 3.0 License
+[http://creativecommons.org/licenses/by/3.0/]
+(Hi Debian folks!) with the following requirements:
+
+"As an author, I would appreciate a reference to my authorship of the Silk icon
+set contents within a readme file or equivalent documentation for the software
+which includes the set or a subset of the icons contained within."


### PR DESCRIPTION
https://wiki.debian.org/DFSGLicenses#Creative_Commons_Attribution_Share-Alike_.28CC-BY-SA.29_v3.0

"In contrast to the CC-SA 1.0 license, version 3.0 is considered to be compatible to the DFSG. In addition, the version 2.0 and 2.5 are NOT transitively compatible because of clause 4b, since that only allows redistribution of derivative works under later versions of the license."
