### PR TITLE
Correct spelling of "suppress" and "suppressor"

### DIFF
--- a/src/logcapture.h
+++ b/src/logcapture.h
@@ -29,7 +29,7 @@
 #include <wx/string.h>
 #include <wx/log.h>
 
-// Capture all wx log output into a text buffer and supress normal output:
+// Capture all wx log output into a text buffer and suppress normal output:
 class LogCapture : public wxLogInterposer
 {
 public:

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -188,7 +188,7 @@ static void AddCatalogToList(wxListCtrl *list, int i, int id, const wxString& fi
     }
     else
     {
-        // supress error messages, we don't mind if the catalog is corrupted
+        // suppress error messages, we don't mind if the catalog is corrupted
         // FIXME: *do* indicate error somehow
         wxLogNull nullLog;
 

--- a/src/prefsdlg.cpp
+++ b/src/prefsdlg.cpp
@@ -80,7 +80,7 @@ class PrefsPanel : public wxPanel
 {
 public:
     PrefsPanel(wxWindow *parent)
-        : wxPanel(parent), m_supressDataTransfer(0)
+        : wxPanel(parent), m_suppressDataTransfer(0)
     {
 #ifdef __WXOSX__
         // Refresh the content of prefs panels when re-opening it.
@@ -100,11 +100,11 @@ public:
 
     bool TransferDataToWindow() override
     {
-        if (m_supressDataTransfer)
+        if (m_suppressDataTransfer)
             return false;
-        m_supressDataTransfer++;
+        m_suppressDataTransfer++;
         InitValues(*wxConfig::Get());
-        m_supressDataTransfer--;
+        m_suppressDataTransfer--;
 
         // This is a "bit" of a hack: we take advantage of being in the last point before
         // showing the window and re-layout it on the off chance that some data transfered
@@ -119,11 +119,11 @@ public:
 
     bool TransferDataFromWindow() override
     {
-        if (m_supressDataTransfer)
+        if (m_suppressDataTransfer)
             return false;
-        m_supressDataTransfer++;
+        m_suppressDataTransfer++;
         SaveValues(*wxConfig::Get());
-        m_supressDataTransfer--;
+        m_suppressDataTransfer--;
         return true;
     }
 
@@ -137,7 +137,7 @@ protected:
     virtual void InitValues(const wxConfigBase& cfg) = 0;
     virtual void SaveValues(wxConfigBase& cfg) = 0;
 
-    int m_supressDataTransfer;
+    int m_suppressDataTransfer;
 };
 
 
@@ -663,9 +663,9 @@ private:
             wxID_OK
         );
 
-        m_supressDataTransfer++;
+        m_suppressDataTransfer++;
         dlg->ShowWindowModalThenDo([=](int retcode){
-            m_supressDataTransfer--;
+            m_suppressDataTransfer--;
             (void)dlg; // force use
             if (retcode == wxID_OK)
             {
@@ -684,7 +684,7 @@ private:
 
     void OnNewExtractor(wxCommandEvent&)
     {
-        m_supressDataTransfer++;
+        m_suppressDataTransfer++;
 
         Extractor info;
         m_extractors.Data.push_back(info);
@@ -702,7 +702,7 @@ private:
                 m_extractors.Data.erase(m_extractors.Data.begin() + index);
             }
 
-            m_supressDataTransfer--;
+            m_suppressDataTransfer--;
 
             if (wxPreferencesEditor::ShouldApplyChangesImmediately())
                 TransferDataFromWindow();

--- a/src/text_control.cpp
+++ b/src/text_control.cpp
@@ -77,19 +77,19 @@ inline ITextDocumentPtr TextDocument(wxTextCtrl *ctrl)
     return doc;
 }
 
-// Temporarily supresses recording of changes for Undo/Redo functionality
+// Temporarily suppresses recording of changes for Undo/Redo functionality
 // See http://stackoverflow.com/questions/4138981/temporaily-disabling-the-c-sharp-rich-edit-undo-buffer-while-performing-syntax-h
 // and http://forums.codeguru.com/showthread.php?325068-Realizing-Undo-Redo-functionality-for-RichEdit-Syntax-Highlighter
-class UndoSupressor
+class UndoSuppressor
 {
 public:
-    UndoSupressor(CustomizedTextCtrl *ctrl) : m_doc(TextDocument(ctrl))
+    UndoSuppressor(CustomizedTextCtrl *ctrl) : m_doc(TextDocument(ctrl))
     {
         if (m_doc)
             m_doc->Undo(tomSuspend, NULL);
     }
 
-    ~UndoSupressor()
+    ~UndoSuppressor()
     {
         if (m_doc)
             m_doc->Undo(tomResume, NULL);
@@ -381,7 +381,7 @@ void AnyTranslatableTextCtrl::DoSetValue(const wxString& value, int flags)
 void AnyTranslatableTextCtrl::UpdateRTLStyle()
 {
     wxEventBlocker block(this, wxEVT_TEXT);
-    UndoSupressor blockUndo(this);
+    UndoSuppressor blockUndo(this);
 
     PARAFORMAT2 pf;
     ::ZeroMemory(&pf, sizeof(pf));
@@ -432,7 +432,7 @@ void AnyTranslatableTextCtrl::HighlightText()
 
     wxEventBlocker block(this, wxEVT_TEXT);
   #ifdef __WXMSW__
-    UndoSupressor blockUndo(this);
+    UndoSuppressor blockUndo(this);
   #endif
 
     auto deflt = m_attrs->Default();


### PR DESCRIPTION
"Suppress" has two P's, even in British English.