### PR TITLE
Revert "Fix pasting into selection to replace it on GTK+"

### DIFF
--- a/src/text_control.cpp
+++ b/src/text_control.cpp
@@ -524,13 +524,7 @@ void AnyTranslatableTextCtrl::HighlightText()
 
 #else // !__WXOSX__
 
-#ifndef __WXGTK__
-    // Freezing (and more to the point, thawing) the window from inside wxEVT_TEXT
-    // handler breaks pasting under GTK+ (selection is not replaced).
-    // See https://github.com/vslavik/poedit/issues/139
     wxWindowUpdateLocker noupd(this);
-#endif
-
     wxEventBlocker block(this, wxEVT_TEXT);
   #ifdef __WXMSW__
     UndoSuppressor blockUndo(this);


### PR DESCRIPTION
This reverts commit baa727e8dea01e63e3632eb2e55274f5b78b4877.

This special-casing is no longer necessary now that OnCut, OnCopy, and
OnPaste are implemented on GTK.

I'm not actually sure if you want to keep the special-casing or not, but I wanted to bring it to your attention. The special-casing doesn't seem to make a functional difference either way.