### PR TITLE
Select the tab that contains the search result

### DIFF
--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -2062,7 +2062,7 @@ void PoeditFrame::OnClearTranslation(wxCommandEvent&)
 void PoeditFrame::OnFind(wxCommandEvent&)
 {
     if (!m_findWindow)
-        m_findWindow = new FindFrame(this, m_list, m_catalog, m_textOrig, m_textTrans);
+        m_findWindow = new FindFrame(this, m_list, m_catalog, m_textOrig, m_textTrans, m_pluralNotebook);
 
     m_findWindow->ShowForFind();
 }
@@ -2070,7 +2070,7 @@ void PoeditFrame::OnFind(wxCommandEvent&)
 void PoeditFrame::OnFindAndReplace(wxCommandEvent&)
 {
     if (!m_findWindow)
-        m_findWindow = new FindFrame(this, m_list, m_catalog, m_textOrig, m_textTrans);
+        m_findWindow = new FindFrame(this, m_list, m_catalog, m_textOrig, m_textTrans, m_pluralNotebook);
 
     m_findWindow->ShowForReplace();
 }

--- a/src/findframe.cpp
+++ b/src/findframe.cpp
@@ -32,6 +32,7 @@
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 #include <wx/checkbox.h>
+#include <wx/notebook.h>
 
 #ifdef __WXOSX__
 #include <AppKit/AppKit.h>
@@ -75,14 +76,16 @@ FindFrame::FindFrame(PoeditFrame *owner,
                      PoeditListCtrl *list,
                      const CatalogPtr& c,
                      CustomizedTextCtrl *textCtrlOrig,
-                     CustomizedTextCtrl *textCtrlTrans)
+                     CustomizedTextCtrl *textCtrlTrans,
+                     wxNotebook *pluralNotebook)
         : wxFrame(owner, wxID_ANY, _("Find"), wxDefaultPosition, wxDefaultSize, FRAME_STYLE),
           m_owner(owner),
           m_listCtrl(list),
           m_catalog(c),
           m_position(-1),
           m_textCtrlOrig(textCtrlOrig),
-          m_textCtrlTrans(textCtrlTrans)
+          m_textCtrlTrans(textCtrlTrans),
+          m_pluralNotebook(pluralNotebook)
 {
     auto panel = new wxPanel(this, wxID_ANY);
     wxBoxSizer *panelsizer = new wxBoxSizer(wxVERTICAL);
@@ -403,17 +406,17 @@ bool IsTextInString(wxString str, const wxString& text,
                                  [=](const wxString&,size_t,size_t){ return wxString::npos;/*just 1 hit*/ });
 }
 
-bool IsTextInStrings(const wxArrayString& strs, const wxString& text,
+size_t IsTextInStrings(const wxArrayString& strs, const wxString& text,
                      bool ignoreCase, bool wholeWords, bool ignoreAmp, bool ignoreUnderscore)
 {
     // loop through all strings and search for the substring in them
     for (size_t i = 0; i < strs.GetCount(); i++)
     {
         if (IsTextInString(strs[i], text, ignoreCase, wholeWords, ignoreAmp, ignoreUnderscore))
-            return true;
+            return i;
     }
 
-    return false;
+    return -1;
 }
 
 bool ReplaceTextInString(wxString& str, const wxString& text, bool wholeWords, const wxString& replacement)
@@ -452,6 +455,7 @@ bool FindFrame::DoFind(int dir)
     bool wholeWords = m_wholeWords->GetValue();
     bool wrapAround = m_wrapAround->GetValue();
     int posOrig = m_position;
+    size_t trans;
 
     FoundState found = Found_Not;
     CatalogItemPtr lastItem;
@@ -492,7 +496,8 @@ bool FindFrame::DoFind(int dir)
 
         if (inTrans)
         {
-            if (IsTextInStrings(dt->GetTranslations(), text, ignoreCase, wholeWords, ignoreAmp, ignoreUnderscore))
+            trans = IsTextInStrings(dt->GetTranslations(), text, ignoreCase, wholeWords, ignoreAmp, ignoreUnderscore);
+            if (trans != (size_t)-1)
             {
                 found = Found_InTrans;
                 break;
@@ -513,7 +518,7 @@ bool FindFrame::DoFind(int dir)
                 found = Found_InComments;
                 break;
             }
-            if (IsTextInStrings(dt->GetExtractedComments(), text, ignoreCase, wholeWords, false, false))
+            if (IsTextInStrings(dt->GetExtractedComments(), text, ignoreCase, wholeWords, false, false) != (size_t)-1)
             {
                 found = Found_InExtractedComments;
                 break;
@@ -537,7 +542,15 @@ bool FindFrame::DoFind(int dir)
               txt = m_textCtrlOrig;
               break;
             case Found_InTrans:
-              txt = m_textCtrlTrans;
+              if (lastItem->GetNumberOfTranslations() == 1)
+              {
+                  txt = m_textCtrlTrans;
+              }
+              else
+              {
+                  m_pluralNotebook->SetSelection(trans);
+                  txt = (CustomizedTextCtrl*)m_pluralNotebook->GetCurrentPage();
+              }
               break;
             case Found_InComments:
             case Found_InExtractedComments:

--- a/src/findframe.h
+++ b/src/findframe.h
@@ -56,7 +56,8 @@ class FindFrame : public wxFrame
             \param catalog Catalog to search in
          */
         FindFrame(PoeditFrame *owner, PoeditListCtrl *list, const CatalogPtr& c,
-                  CustomizedTextCtrl *textCtrlOrig, CustomizedTextCtrl *textCtrlTrans);
+                  CustomizedTextCtrl *textCtrlOrig, CustomizedTextCtrl *textCtrlTrans,
+                  wxNotebook *pluralNotebook);
         ~FindFrame();
 
         /** Resets the search to starting position and changes
@@ -96,6 +97,7 @@ class FindFrame : public wxFrame
         CatalogItemPtr m_lastItem;
         wxButton *m_btnClose, *m_btnReplaceAll, *m_btnReplace, *m_btnPrev, *m_btnNext;
         CustomizedTextCtrl *m_textCtrlOrig, *m_textCtrlTrans;
+        wxNotebook *m_pluralNotebook;
 
         // NB: this is static so that last search term is remembered
         static wxString ms_text;


### PR DESCRIPTION
Before you freak out over the goto, look this code over carefully. The goto keyword is appropriate in this case because 1) we need to break out of a double loop and 2) it avoids redundant if statements.