### PR TITLE
Fix compiler warning: extra tokens at end of #else directive

### DIFF
--- a/src/propertiesdlg.cpp
+++ b/src/propertiesdlg.cpp
@@ -188,7 +188,7 @@ public:
 #elif defined(__WXMSW__)
         auto add = new wxBitmapButton(this, wxID_ANY, wxArtProvider::GetBitmap("list-add"), wxDefaultPosition, wxSize(19,19));
         auto remove = new wxBitmapButton(this, wxID_ANY, wxArtProvider::GetBitmap("list-remove"), wxDefaultPosition, wxSize(19,19));
-#else defined(__WXGTK__)
+#else // defined(__WXGTK__)
         auto add = new wxBitmapButton(this, wxID_ANY, wxArtProvider::GetBitmap("list-add"), wxDefaultPosition, wxDefaultSize, wxNO_BORDER);
         auto remove = new wxBitmapButton(this, wxID_ANY, wxArtProvider::GetBitmap("list-remove"), wxDefaultPosition, wxDefaultSize, wxNO_BORDER);
 #endif


### PR DESCRIPTION
Currently there is the following compiler warning:
propertiesdlg.cpp:191:7: warning: extra tokens at end of #else directive
 #else defined(__WXGTK__)
