### PR TITLE
Set language code for Javanese to "jv".

### DIFF
--- a/src/language_impl_legacy.h
+++ b/src/language_impl_legacy.h
@@ -69,7 +69,7 @@ static const std::unordered_map<std::string, std::string> isoLanguages = {
     { "Irish", "ga" },
     { "Italian", "it" },
     { "Japanese", "ja" },
-    { "Javanese", "jw" },
+    { "Javanese", "jv" },
     { "Kalaallisut", "kl" },
     { "Kannada", "kn" },
     { "Kashmiri", "ks" },


### PR DESCRIPTION
The "jw" language code was published in error.
It was withdrawn in favor of "jv" in 2001.

Source: http://www.loc.gov/standards/iso639-2/php/code_changes.php