### PR TITLE
Fix Unix installation instructions, fixes #238

### DIFF
--- a/README
+++ b/README
@@ -46,6 +46,7 @@ Optional dependencies:
 
 Do the usual thing:
 
+    ./bootstrap
     ./configure
     make
     make install


### PR DESCRIPTION
Adding missing `./bootstrap` command before running `./configure`,
whether the instruction is still "usual" or not is left intact.

Signed-off-by: Ｖ字龍 <Vdragon.Taiwan@gmail.com>