### PR TITLE
add pthread to cpprest builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AS_IF([test "x$with_cpprest" != "xno"],
               [
                   AC_MSG_CHECKING([for libcpprest >= 2.5])
                   old_LIBS="$LIBS"
-                  LIBS="-lcpprest -lboost_system -lssl -lcrypto $LIBS"
+                  LIBS="-lcpprest -lboost_system -lssl -lcrypto -lpthread $LIBS"
                   AC_LINK_IFELSE([AC_LANG_PROGRAM(
                       [
                           #include <cpprest/version.h>
@@ -96,7 +96,7 @@ AS_IF([test "x$with_cpprest" != "xno"],
 AS_IF([test "x$have_cpprest" = "xyes"],
       [
           AC_DEFINE([HAVE_HTTP_CLIENT])
-          CPPREST_LIBS="-lcpprest -lboost_system -lssl -lcrypto"
+          CPPREST_LIBS="-lcpprest -lboost_system -lssl -lcrypto -lpthread"
           AC_SUBST(CPPREST_LIBS)
           PKG_CHECK_MODULES([LIBSECRET], [libsecret-1], [
               CXXFLAGS="$CXXFLAGS $LIBSECRET_CFLAGS"


### PR DESCRIPTION
For some reasons also pthread is used on arm* boost linkages.