### PR TITLE
Fix assertion failures with wxWidgets 3.1

### DIFF
--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -88,8 +88,8 @@ CrowdinLoginPanel::CrowdinLoginPanel(wxWindow *parent, int flags)
     sizer->Add(buttons, wxSizerFlags().Expand().Border(wxBOTTOM, 1));
     buttons->Add(learnMore, wxSizerFlags().Center().Border(wxLEFT, PX(LearnMoreLink::EXTRA_INDENT)));
     buttons->AddStretchSpacer();
-    buttons->Add(m_signIn, wxSizerFlags().Right());
-    buttons->Add(m_signOut, wxSizerFlags().Right());
+    buttons->Add(m_signIn, wxSizerFlags());
+    buttons->Add(m_signOut, wxSizerFlags());
 
     if (flags & DialogButtons)
     {

--- a/src/prefsdlg.cpp
+++ b/src/prefsdlg.cpp
@@ -167,12 +167,12 @@ public:
         translator->Add(nameLabel, wxSizerFlags().Center().Right().BORDER_OSX(wxTOP, 1));
         m_userName = new wxTextCtrl(this, wxID_ANY);
         m_userName->SetHint(_("Your Name"));
-        translator->Add(m_userName, wxSizerFlags(1).Expand().Center());
+        translator->Add(m_userName, wxSizerFlags(1).Expand());
         auto emailLabel = new wxStaticText(this, wxID_ANY, _("Email:"));
         translator->Add(emailLabel, wxSizerFlags().Center().Right().BORDER_OSX(wxTOP, 1));
         m_userEmail = new wxTextCtrl(this, wxID_ANY);
         m_userEmail->SetHint(_("your_email@example.com"));
-        translator->Add(m_userEmail, wxSizerFlags(1).Expand().Center());
+        translator->Add(m_userEmail, wxSizerFlags(1).Expand());
         translator->AddSpacer(PX(1));
         translator->Add(new ExplanationLabel(this, _("Your name and email address are only used to set the Last-Translator header of GNU gettext files.")), wxSizerFlags(1).Expand().PXBorder(wxRIGHT));
 #ifdef __WXOSX__
@@ -220,9 +220,9 @@ public:
         m_fontText->SetMinSize(wxSize(PX(120), -1));
 
         appearance->Add(m_useFontList, wxSizerFlags().Center().Left());
-        appearance->Add(m_fontList, wxSizerFlags().Center().Expand());
+        appearance->Add(m_fontList, wxSizerFlags().Center().Right());
         appearance->Add(m_useFontText, wxSizerFlags().Center().Left());
-        appearance->Add(m_fontText, wxSizerFlags().Center().Expand());
+        appearance->Add(m_fontText, wxSizerFlags().Center().Right());
 
 #if NEED_CHOOSELANG_UI 
         m_uiLanguage = new wxButton(this, wxID_ANY, _("Change UI language"));

--- a/src/resources/properties.xrc
+++ b/src/resources/properties.xrc
@@ -234,7 +234,7 @@
                     <label>Learn about gettext keywords</label>
                     <url>https://poedit.net/trac/wiki/Doc/Keywords</url>
                   </object>
-                  <flag>wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                  <flag>wxLEFT|wxRIGHT|wxBOTTOM|wxALIGN_RIGHT</flag>
                   <border>5d</border>
                 </object>
               </object>

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -97,7 +97,7 @@ SidebarBlock::SidebarBlock(Sidebar *parent, const wxString& label, int flags)
                          wxSizerFlags().Expand().Border(wxBOTTOM|wxLEFT, PX(2)));
         }
         m_headerSizer = new wxBoxSizer(wxHORIZONTAL);
-        m_headerSizer->Add(new HeadingLabel(parent, label), wxSizerFlags().Expand().Center());
+        m_headerSizer->Add(new HeadingLabel(parent, label), wxSizerFlags().Expand());
         m_sizer->Add(m_headerSizer, wxSizerFlags().Expand().PXDoubleBorder(wxLEFT|wxRIGHT));
     }
     m_innerSizer = new wxBoxSizer(wxVERTICAL);


### PR DESCRIPTION
As described in #262 there are a couple of assertion failures with the new wxWidgets version due to the use of ` Expand()`  with alignment flags.
In ` crowdin_gui.cpp` it is illegal to use `Right` in a horizontal sizer
And last `wxALIGN_CENTER_VERTICAL` in the properties.xrc is invalid with this flags or at this point. Suggestion by the assert was to use spacers. Doesn't look bad without them however