### PR TITLE
Silence compiler warning

### DIFF
--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -61,6 +61,9 @@ wxString GetGnomeStockId(const wxString& id)
 // Check if a given icon needs mirroring in right-to-left locales:
 bool ShouldBeMirorredInRTL(const wxArtID& id, const wxArtClient& client)
 {
+    // Silence warning about unused parameter in some of the builds
+    (void)client;
+
     static std::set<wxString> s_directional = {
         "ContributeOn",
         "poedit-status-comment",


### PR DESCRIPTION
icons.cpp:62:66: warning: unused parameter ‘client’ [-Wunused-parameter]
bool ShouldBeMirorredInRTL(const wxArtID& id, const wxArtClient& client)