### PR TITLE
Added an appdata.xml file for software gallery integration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,4 +6,7 @@ SUBDIRS = src docs locales artwork
 desktopdir=$(datadir)/applications
 dist_desktop_DATA = poedit.desktop poedit-uri.desktop
 
+appdatadir=$(datadir)/appdata
+dist_appdata_DATA = poedit.appdata.xml
+
 EXTRA_DIST = bootstrap

--- a/poedit.appdata.xml
+++ b/poedit.appdata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2015 Mario Blättermann <mariobl@fedoraproject.org> -->
+<application>
+  <id type="desktop">poedit.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Poedit</name>
+  <summary>GUI editor for GNU gettext .po files</summary>
+  <summary xml:lang="de">Grafischer Editor für GNU Gettext-Dateien</summary>
+  <description>
+    <p>
+      This program is a GUI frontend to GNU Gettext utilities and a catalogs 
+      editor/source code parser. It helps with translating applications into 
+      other languages.
+    </p>
+    <p xml:lang="de">
+      Dieses Programm stellt eine grafische Benutzeroberfläche für die
+      Dienstprogramme aus GNU Gettext bereit, sowie einen Katalogeditor und
+      einen Quellcode-Parser. Es hilft beim Übersetzen von Anwendungen in
+      andere Sprachen.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://upload.wikimedia.org/wikipedia/commons/c/c2/Poedit_1.8.1_en.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://poedit.net</url>
+  <updatecontact>help@poedit.net</updatecontact>
+</application>


### PR DESCRIPTION
This file was created by @mariobl for Fedora. While incorporating it into openSUSE I thought it would be best to contribute it upstream. Adjusted the `updatecontact` tag accordingly.

https://people.freedesktop.org/~hughsient/appdata/ gives some explanation on what this is about.