### PR TITLE
avoid deprecated gtk_widget_size_request()

### DIFF
--- a/src/wx_backports/wx_gtk_nativewin.cpp
+++ b/src/wx_backports/wx_gtk_nativewin.cpp
@@ -61,7 +61,7 @@ wxNativeWindow::Create(wxWindow* parent,
     // Ensure that the best (and minimal) size is set to fully display the
     // widget.
     GtkRequisition req;
-    gtk_widget_size_request(widget, &req);
+    gtk_widget_get_preferred_size(widget, NULL, &req);
     SetInitialSize(wxSize(req.width, req.height));
 
     return true;

--- a/src/wx_backports/wx_gtk_nativewin.cpp
+++ b/src/wx_backports/wx_gtk_nativewin.cpp
@@ -61,7 +61,11 @@ wxNativeWindow::Create(wxWindow* parent,
     // Ensure that the best (and minimal) size is set to fully display the
     // widget.
     GtkRequisition req;
+#ifdef __WXGTK3__
     gtk_widget_get_preferred_size(widget, NULL, &req);
+#else
+    gtk_widget_size_request(widget, &req);
+#endif
     SetInitialSize(wxSize(req.width, req.height));
 
     return true;


### PR DESCRIPTION
gtk_widget_size_request has been deprecated since GtkWidget version 3.0.

Avoids compiler warnings like:

`wx_backports/wx_gtk_nativewin.cpp: In member function ‘bool xNativeWindow::Create(wxWindow*, wxWindowID, wxNativeWindowHandle)’:
wx_backports/wx_gtk_nativewin.cpp:64:5: warning: ‘void gtk_widget_size_request(GtkWidget*, GtkRequisition*)’ is deprecated: Use 'gtk_widget_get_preferred_size' instead [-Wdeprecated-declarations] gtk_widget_size_request(widget, &req);`
