### PR TITLE
Support for command-line switch --line

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -1365,13 +1365,19 @@ void Catalog::RemoveDeletedItems()
 
 CatalogItemPtr Catalog::FindItemByLine(int lineno)
 {
-    CatalogItemPtr last;
+    int i = FindItemIndexByLine(lineno);
+    return i == -1 ? CatalogItemPtr() : m_items[i];
+}
+
+int Catalog::FindItemIndexByLine(int lineno)
+{
+    int last = -1;
 
     for (auto& i: m_items)
     {
-        if ( i->GetLineNumber() > lineno )
+        if (i->GetLineNumber() > lineno)
             return last;
-        last = i;
+        last++;
     }
 
     return last;

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -709,6 +709,9 @@ class Catalog
         /// Finds item by line number
         CatalogItemPtr FindItemByLine(int lineno);
 
+        /// Finds catalog index by line number
+        int FindItemIndexByLine(int lineno);
+
         /// Sets the given item to have the given bookmark and returns the index
         /// of the item that previously had this bookmark (or -1)
         int SetBookmark(int id, Bookmark bookmark);

--- a/src/edapp.h
+++ b/src/edapp.h
@@ -61,7 +61,7 @@ class PoeditApp : public wxApp
         bool CheckForBetaUpdates() const;
 
         // opens files in new frame
-        void OpenFiles(const wxArrayString& filenames);
+        void OpenFiles(const wxArrayString& filenames, int lineno = 0);
         // opens empty frame or catalogs manager
         void OpenNewFile();
 
@@ -70,7 +70,7 @@ class PoeditApp : public wxApp
 #endif
 
 #ifdef __WXOSX__
-        virtual void MacOpenFiles(const wxArrayString& names) { OpenFiles(names); }
+        virtual void MacOpenFiles(const wxArrayString& names);
         virtual void MacNewFile() { OpenNewFile(); }
         virtual void MacOpenURL(const wxString &url) { HandleCustomURI(url); }
 #endif

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -212,7 +212,7 @@ bool g_focusToText = false;
     return false;
 }
 
-/*static*/ PoeditFrame *PoeditFrame::Create(const wxString& filename)
+/*static*/ PoeditFrame *PoeditFrame::Create(const wxString& filename, int lineno)
 {
     PoeditFrame *f = PoeditFrame::Find(filename);
     if (f)
@@ -245,7 +245,9 @@ bool g_focusToText = false;
     }
 
     f->Show(true);
-    f->PlaceInitialFocus();
+
+    // HACK: make sure this is called *after* the delayed call in PoeditListCtrl::CatalogChanged
+    f->m_list->CallAfter([=]{ f->PlaceInitialFocus(lineno); });
 
     return f;
 }
@@ -786,15 +788,23 @@ PoeditFrame::~PoeditFrame()
 }
 
 
-void PoeditFrame::PlaceInitialFocus()
+void PoeditFrame::PlaceInitialFocus(int lineno)
 {
     if (g_focusToText && m_editingArea)
         m_editingArea->SetTextFocus();
     else if (m_list)
         m_list->SetFocus();
 
-    if (m_list && m_list->GetItemCount() > 0)
-        m_list->SelectAndFocus(0);
+    if (m_catalog && m_list && m_list->GetItemCount() > 0)
+    {
+        int item = 0;
+        if (lineno > 0)
+        {
+            item = m_catalog->FindItemIndexByLine(lineno);
+            item = (item == -1) ? 0 : m_list->CatalogIndexToList(item);
+        }
+        m_list->SelectAndFocus(item);
+    }
 }
 
 
@@ -916,19 +926,20 @@ void PoeditFrame::OnCloseCmd(wxCommandEvent&)
 #endif
 
 
-void PoeditFrame::OpenFile(const wxString& filename)
+void PoeditFrame::OpenFile(const wxString& filename, int lineno)
 {
     DoIfCanDiscardCurrentDoc([=]{
-        DoOpenFile(filename);
+        DoOpenFile(filename, lineno);
     });
 }
 
 
-void PoeditFrame::DoOpenFile(const wxString& filename)
+void PoeditFrame::DoOpenFile(const wxString& filename, int lineno)
 {
     ReadCatalog(filename);
 
-    PlaceInitialFocus();
+    // HACK: make sure this is called *after* the delayed call in PoeditListCtrl::CatalogChanged
+    m_list->CallAfter([=]{ PlaceInitialFocus(lineno); });
 }
 
 

--- a/src/edframe.h
+++ b/src/edframe.h
@@ -69,7 +69,7 @@ class PoeditFrame : public PoeditFrameBase
 
             \param catalog filename of catalog to open.
          */
-        static PoeditFrame *Create(const wxString& catalog);
+        static PoeditFrame *Create(const wxString& catalog, int lineno = 0);
 
         /** Public constructor functions. Creates and shows frame
             without catalog or other content.
@@ -83,7 +83,7 @@ class PoeditFrame : public PoeditFrameBase
 
         /// Opens given file in this frame. Asks user for permission first
         /// if there's unsaved document.
-        void OpenFile(const wxString& filename);
+        void OpenFile(const wxString& filename, int lineno = 0);
 
         /** Returns pointer to existing instance of PoeditFrame that currently
             exists and edits \a catalog. If no such frame exists, returns NULL.
@@ -183,7 +183,7 @@ class PoeditFrame : public PoeditFrameBase
         wxWindow* CreateContentViewEmptyPO();
         void DestroyContentView();
 
-        void PlaceInitialFocus();
+        void PlaceInitialFocus(int lineno = 0);
 
         typedef std::set<PoeditFrame*> PoeditFramesList;
         static PoeditFramesList ms_instances;
@@ -206,7 +206,7 @@ class PoeditFrame : public PoeditFrameBase
         wxWindowPtr<wxMessageDialog> CreateAskAboutSavingDialog();
 
         // implements opening of files, without asking user
-        void DoOpenFile(const wxString& filename);
+        void DoOpenFile(const wxString& filename, int lineno = 0);
 
         /// Updates statistics in statusbar.
         void UpdateStatusBar();


### PR DESCRIPTION
This adds support for the new command-line switch --go-to-line=<num>,
where <num> is the number of line in the .po file. This is related to
issue #356 on vslavik/poedit. It has been compiled with Visual Studio 2015 and tested on Windows.