### PR TITLE
configure.ac: check for system json.hpp if available, and use it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ AS_IF([test "x$have_cpprest" = "xyes"],
       ])
 AM_CONDITIONAL([HAVE_CPPREST], [test "x$have_cpprest" != "xno"])
 
-
+AC_CHECK_HEADERS([json.hpp])
 
 WX_CONFIG_CHECK([3.0.1], [WXFOUND=1], [WXFOUND=0], [$WXLIBS_USED], [--unicode])
 

--- a/src/json.h
+++ b/src/json.h
@@ -28,7 +28,12 @@
 
 #include "str_helpers.h"
 
+#ifdef HAVE_JSON_HPP
+#include <json.hpp>
+#else
 #include "json/src/json.hpp"
+#endif
+
 using json = nlohmann::json;
 
 


### PR DESCRIPTION
 (Issue: #372)