### PR TITLE
Fix overlapping crowdin name and username (wxGTK3)

### DIFF
--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -166,7 +166,13 @@ void CrowdinLoginPanel::CreateLoginInfoControls(State state)
         {
             auto account = new wxStaticText(this, wxID_ANY, _("Signed in as:"));
             account->SetForegroundColour(SecondaryLabel::GetTextColor());
+#ifdef __WXGTK3__
+            // Under wxGTK3, there is not enough space for the name. Longer names are wrapped and overlap with the username then
+            // Hard code an inital horizontal width for wxSize and ellipsize longer names as a workaround
+            auto name = new wxStaticText(this, wxID_ANY, m_userName, wxPoint(), wxSize(150,-1), wxST_ELLIPSIZE_END);
+#else
             auto name = new wxStaticText(this, wxID_ANY, m_userName);
+#endif
             name->SetFont(name->GetFont().Bold());
             auto username = new SecondaryLabel(this, m_userLogin);
 
@@ -174,6 +180,8 @@ void CrowdinLoginPanel::CreateLoginInfoControls(State state)
             sizer->AddSpacer(PX(2));
             auto box = new wxBoxSizer(wxVERTICAL);
             box->Add(name, wxSizerFlags().Left());
+            // A spacer in between would also improve the overlapping of name and username under wxGTK3
+            // box->AddSpacer(PX(25));
             box->Add(username, wxSizerFlags().Left());
             sizer->Add(box);
             break;


### PR DESCRIPTION
- Under wxGTK3, there is not enough space allocated for the name. Longer names
  are wrapped and overlap with the username then. See screenshot below.
- Hard code an initial horizontal width for wxSize and ellipsize longer
  names as a workaround

Poedit version: 2.0.2
OS: Fedora 26 x86_64
wxGTK3 version: 3.0.3
GTK+ version: 3.22.16
 
Overlapping name and username in Poedit 2.0.2:

![poedit_2 0 2_prefs_crowdin_screenshot_name_overlap](https://user-images.githubusercontent.com/371551/27962248-94aae404-6331-11e7-9289-e3039899bc95.png)

This is how it looks with the modified crowdin_gui.cpp:

![poedit_2 0 2_prefs_crowdin_screenshot_name_no-overlap](https://user-images.githubusercontent.com/371551/27962277-b42eace8-6331-11e7-9d86-f58261279cfd.png)

