### PR TITLE
Adding ja comma to isEquivalent

### DIFF
--- a/src/qa_checks.cpp
+++ b/src/qa_checks.cpp
@@ -241,6 +241,8 @@ private:
                     return trans == L'（';
                 case ')':
                     return trans == L'）';
+                case ', ':
+                    return trans == L'、';
                 default:
                     break;
             }


### PR DESCRIPTION
In Japanese, the regular comma used includes whitespace at the end of
the character since it would normally be a full width character. In
English, a comma has whitespace at the end, but its a separate
character. This change makes it so that the IsEquivalent check
recognizes ", " and "、" as functionally the same set of characters.
The reason this is different than the full width period, is that a
translation that ends with a comma in English needs the space afterwards
which is not true for periods.

in reference to #issue 437