### PR TITLE
Update "Don't save" button: Add accelerator

### DIFF
--- a/locales/an.po
+++ b/locales/an.po
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Save"
 msgstr "Alzar"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/ar.po
+++ b/locales/ar.po
@@ -430,7 +430,7 @@ msgstr "ستفقد تعديلاتك إن لم تحفظها."
 msgid "Save"
 msgstr "احفظ"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "لا تحفظ"
 
 msgid "Don’t Save"

--- a/locales/az.po
+++ b/locales/az.po
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Save"
 msgstr "Qeyd et"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Qeyd etmə"
 
 msgid "Don’t Save"

--- a/locales/be.po
+++ b/locales/be.po
@@ -433,7 +433,7 @@ msgstr "Вашы змены будуць страчаныя, калі вы не 
 msgid "Save"
 msgstr "Захаваць"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Не захоўваць"
 
 msgid "Don’t Save"

--- a/locales/be@latin.po
+++ b/locales/be@latin.po
@@ -427,7 +427,7 @@ msgstr ""
 msgid "Save"
 msgstr "Zapišy"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/bg.po
+++ b/locales/bg.po
@@ -433,7 +433,7 @@ msgstr "Направените промени ще бъдат загубени, 
 msgid "Save"
 msgstr "&Запазване"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Без запазване"
 
 msgid "Don’t Save"

--- a/locales/bs.po
+++ b/locales/bs.po
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Save"
 msgstr "Sačuvaj"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/ca.po
+++ b/locales/ca.po
@@ -437,8 +437,8 @@ msgstr "Els canvis es perdran si no els deseu."
 msgid "Save"
 msgstr "Desa"
 
-msgid "Don’t save"
-msgstr "No ho desis"
+msgid "Do&n’t save"
+msgstr "&No ho desis"
 
 msgid "Don’t Save"
 msgstr "No ho desis"

--- a/locales/ckb.po
+++ b/locales/ckb.po
@@ -426,7 +426,7 @@ msgstr ""
 msgid "Save"
 msgstr "پاشەکەوت کردن"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/co.po
+++ b/locales/co.po
@@ -433,7 +433,7 @@ msgstr ""
 msgid "Save"
 msgstr "Arregistrà"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/cs.po
+++ b/locales/cs.po
@@ -435,8 +435,8 @@ msgstr "Pokud je neuložíte, přijdete o všechny změny."
 msgid "Save"
 msgstr "Uložit"
 
-msgid "Don’t save"
-msgstr "Neukládat"
+msgid "Do&n’t save"
+msgstr "&Neukládat"
 
 msgid "Don’t Save"
 msgstr "Neukládat"

--- a/locales/da.po
+++ b/locales/da.po
@@ -429,7 +429,7 @@ msgstr "Dine ændringer vil gå tabt hvis du ikke gemmer dem."
 msgid "Save"
 msgstr "Gem"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Gem ikke"
 
 msgid "Don’t Save"

--- a/locales/de.po
+++ b/locales/de.po
@@ -442,8 +442,8 @@ msgstr "Ihre Änderungen gehen verloren, wenn Sie diese nicht speichern."
 msgid "Save"
 msgstr "Speichern"
 
-msgid "Don’t save"
-msgstr "Nicht speichern"
+msgid "Do&n’t save"
+msgstr "&Nicht speichern"
 
 msgid "Don’t Save"
 msgstr "Nicht speichern"

--- a/locales/el.po
+++ b/locales/el.po
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Save"
 msgstr "Αποθήκευση"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Να μην αποθηκευθεί"
 
 msgid "Don’t Save"

--- a/locales/en_GB.po
+++ b/locales/en_GB.po
@@ -431,8 +431,8 @@ msgstr "Your changes will be lost if you don’t save them."
 msgid "Save"
 msgstr "Save"
 
-msgid "Don’t save"
-msgstr "Don’t save"
+msgid "Do&n’t save"
+msgstr "Do&n’t save"
 
 msgid "Don’t Save"
 msgstr "Don’t Save"

--- a/locales/es.po
+++ b/locales/es.po
@@ -432,8 +432,8 @@ msgstr "Los cambios se perderán si no los guarda."
 msgid "Save"
 msgstr "Guardar"
 
-msgid "Don’t save"
-msgstr "No guardar"
+msgid "Do&n’t save"
+msgstr "&No guardar"
 
 msgid "Don’t Save"
 msgstr "No guardar"

--- a/locales/et.po
+++ b/locales/et.po
@@ -421,7 +421,7 @@ msgstr "Tehtud muudatused lähevad kaotsi, kui neid ei salvestata."
 msgid "Save"
 msgstr "Salvesta"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Ära salvesta"
 
 msgid "Don’t Save"

--- a/locales/eu.po
+++ b/locales/eu.po
@@ -437,7 +437,7 @@ msgstr "Zure aldaketak galdu egingo dira ez badituzu gordetzen."
 msgid "Save"
 msgstr "Gorde"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Ez gorde"
 
 msgid "Don’t Save"

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -426,7 +426,7 @@ msgstr "اگر ذخیره نکنید، تغییرات شما از بین می ر
 msgid "Save"
 msgstr "ذخیره"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "ذخیره نکن"
 
 msgid "Don’t Save"

--- a/locales/fi.po
+++ b/locales/fi.po
@@ -435,7 +435,7 @@ msgstr ""
 msgid "Save"
 msgstr "Tallenna"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Älä tallenna"
 
 msgid "Don’t Save"

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -440,8 +440,8 @@ msgstr "Vos modifications seront perdues si vous ne les enregistrez pas."
 msgid "Save"
 msgstr "Enregistrer"
 
-msgid "Don’t save"
-msgstr "Ne pas enregistrer"
+msgid "Do&n’t save"
+msgstr "&Ne pas enregistrer"
 
 msgid "Don’t Save"
 msgstr "Ne pas enregistrer"

--- a/locales/ga.po
+++ b/locales/ga.po
@@ -440,8 +440,8 @@ msgstr "Caillfidh tú do chuid athruithe mura sábhálfaidh tú iad."
 msgid "Save"
 msgstr "Cuir i dtaisce"
 
-msgid "Don’t save"
-msgstr "Ná sábháil"
+msgid "Do&n’t save"
+msgstr "&Ná sábháil"
 
 msgid "Don’t Save"
 msgstr "Ná Sábháil"

--- a/locales/gl.po
+++ b/locales/gl.po
@@ -436,8 +436,8 @@ msgstr "Os cambios perderanse a menos que vostede os garde."
 msgid "Save"
 msgstr "Gardar"
 
-msgid "Don’t save"
-msgstr "Non gardar"
+msgid "Do&n’t save"
+msgstr "&Non gardar"
 
 msgid "Don’t Save"
 msgstr "Non gardar"

--- a/locales/he.po
+++ b/locales/he.po
@@ -428,7 +428,7 @@ msgstr "השינויים שביצעת יאבדו אם לא תשמור אותם."
 msgid "Save"
 msgstr "שמור"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "אל תשמור"
 
 msgid "Don’t Save"

--- a/locales/hr.po
+++ b/locales/hr.po
@@ -437,8 +437,8 @@ msgstr ""
 msgid "Save"
 msgstr "Spremi"
 
-msgid "Don’t save"
-msgstr "Nemoj spremiti"
+msgid "Do&n’t save"
+msgstr "&Nemoj spremiti"
 
 msgid "Don’t Save"
 msgstr "Nemoj spremiti"

--- a/locales/hu.po
+++ b/locales/hu.po
@@ -437,8 +437,8 @@ msgstr "A változtatások elvesznek, ha nem menti azokat."
 msgid "Save"
 msgstr "Mentés"
 
-msgid "Don’t save"
-msgstr "Nincs mentés"
+msgid "Do&n’t save"
+msgstr "&Nincs mentés"
 
 msgid "Don’t Save"
 msgstr "Nincs mentés"

--- a/locales/hy.po
+++ b/locales/hy.po
@@ -430,7 +430,7 @@ msgstr "Եթե չպահպանեք փոփոխությունները, ապա կկ�
 msgid "Save"
 msgstr "Պահպանել"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Չպահպանել"
 
 msgid "Don’t Save"

--- a/locales/id.po
+++ b/locales/id.po
@@ -433,7 +433,7 @@ msgstr "Perubahan yang Anda buat akan hilang bila tidak Anda simpan."
 msgid "Save"
 msgstr "Simpan"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Jangan simpan"
 
 msgid "Don’t Save"

--- a/locales/is.po
+++ b/locales/is.po
@@ -431,7 +431,7 @@ msgstr "Breytingar tapast ef þú vistar þær ekki."
 msgid "Save"
 msgstr "Vista"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Ekki vista"
 
 msgid "Don’t Save"

--- a/locales/it.po
+++ b/locales/it.po
@@ -438,8 +438,8 @@ msgstr "Le modifiche saranno perse se non le salvi."
 msgid "Save"
 msgstr "Salva"
 
-msgid "Don’t save"
-msgstr "Non salvare"
+msgid "Do&n’t save"
+msgstr "&Non salvare"
 
 msgid "Don’t Save"
 msgstr "Non salvare"

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -428,7 +428,7 @@ msgstr "保存しないと追加した変更は失われます。"
 msgid "Save"
 msgstr "保存"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "保存しない"
 
 msgid "Don’t Save"

--- a/locales/ka.po
+++ b/locales/ka.po
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Save"
 msgstr "შენახვა"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/kab.po
+++ b/locales/kab.po
@@ -431,7 +431,7 @@ msgstr "Ibeddilen-ik ad ruḥen ma yella ur ten-teskelseḍ ara."
 msgid "Save"
 msgstr "Sekles"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Ur seklas ara"
 
 msgid "Don’t Save"

--- a/locales/kk.po
+++ b/locales/kk.po
@@ -425,7 +425,7 @@ msgstr "Өзгерістерді сақтамасаңыз, олар жоғала
 msgid "Save"
 msgstr "Сақтау"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Сақтамау"
 
 msgid "Don’t Save"

--- a/locales/ko.po
+++ b/locales/ko.po
@@ -426,7 +426,7 @@ msgstr "저장하지 않을 경우 변경 사항은 손실됩니다."
 msgid "Save"
 msgstr "저장"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "저장하지 않음"
 
 msgid "Don’t Save"

--- a/locales/lt.po
+++ b/locales/lt.po
@@ -432,8 +432,8 @@ msgstr "Prarasite atliktus pakeitimus, jei jų neišsaugosite."
 msgid "Save"
 msgstr "Įrašyti"
 
-msgid "Don’t save"
-msgstr "Neįrašyti"
+msgid "Do&n’t save"
+msgstr "&Neįrašyti"
 
 msgid "Don’t Save"
 msgstr "Neįrašyti"

--- a/locales/lv.po
+++ b/locales/lv.po
@@ -425,8 +425,8 @@ msgstr ""
 msgid "Save"
 msgstr "Saglabāt"
 
-msgid "Don’t save"
-msgstr "Nesaglabāt"
+msgid "Do&n’t save"
+msgstr "&Nesaglabāt"
 
 msgid "Don’t Save"
 msgstr "Nesaglabāt"

--- a/locales/ms.po
+++ b/locales/ms.po
@@ -433,7 +433,7 @@ msgstr "Perubahan anda akan hilang jika anda tidak menyimpannya."
 msgid "Save"
 msgstr "Simpan"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Jangan simpan"
 
 msgid "Don’t Save"

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -433,7 +433,7 @@ msgstr "Dine endringer vil gå tapt hvis du ikke lagrer dem."
 msgid "Save"
 msgstr "Lagre"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Ikke lagre"
 
 msgid "Don’t Save"

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -439,8 +439,8 @@ msgstr "Uw wijzigingen zullen verloren gaan als u ze niet opslaat."
 msgid "Save"
 msgstr "Opslaan"
 
-msgid "Don’t save"
-msgstr "Niet opslaan"
+msgid "Do&n’t save"
+msgstr "&Niet opslaan"
 
 msgid "Don’t Save"
 msgstr "Niet opslaan"

--- a/locales/oc.po
+++ b/locales/oc.po
@@ -435,7 +435,7 @@ msgstr "Vòstras modificacions seràn perdudas se las enregistratz pas."
 msgid "Save"
 msgstr "Enregistrar"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Enregistrar pas"
 
 msgid "Don’t Save"

--- a/locales/pa.po
+++ b/locales/pa.po
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Save"
 msgstr "ਸੰਭਾਲੋ"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -441,8 +441,8 @@ msgstr "Zmiany zostaną utracone, jeśli nie zostały zapisane."
 msgid "Save"
 msgstr "Zapisz"
 
-msgid "Don’t save"
-msgstr "Nie zapisuj"
+msgid "Do&n’t save"
+msgstr "&Nie zapisuj"
 
 msgid "Don’t Save"
 msgstr "Nie zapisuj"

--- a/locales/poedit.pot
+++ b/locales/poedit.pot
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -436,8 +436,8 @@ msgstr "Suas alterações serão perdidas se você não salvá-las."
 msgid "Save"
 msgstr "Salvar"
 
-msgid "Don’t save"
-msgstr "Não salvar"
+msgid "Do&n’t save"
+msgstr "&Não salvar"
 
 msgid "Don’t Save"
 msgstr "Não salvar"

--- a/locales/pt_PT.po
+++ b/locales/pt_PT.po
@@ -437,8 +437,8 @@ msgstr "Se não guardar as alterações, estas serão perdidas."
 msgid "Save"
 msgstr "Guardar"
 
-msgid "Don’t save"
-msgstr "Não guardar"
+msgid "Do&n’t save"
+msgstr "&Não guardar"
 
 msgid "Don’t Save"
 msgstr "Não guardar"

--- a/locales/ro.po
+++ b/locales/ro.po
@@ -439,8 +439,8 @@ msgstr "Modificările vor fi pierdute dacă nu le salvați."
 msgid "Save"
 msgstr "Salvează"
 
-msgid "Don’t save"
-msgstr "Nu salva"
+msgid "Do&n’t save"
+msgstr "&Nu salva"
 
 msgid "Don’t Save"
 msgstr "Nu Salva"

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -437,7 +437,7 @@ msgstr "Ваши изменения будут потеряны, если не �
 msgid "Save"
 msgstr "Сохранить"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Не сохранять"
 
 msgid "Don’t Save"

--- a/locales/sk.po
+++ b/locales/sk.po
@@ -440,8 +440,8 @@ msgstr "Vaše úpravy budú stratené ak ich neuložíte."
 msgid "Save"
 msgstr "Uložiť"
 
-msgid "Don’t save"
-msgstr "Neukladať"
+msgid "Do&n’t save"
+msgstr "&Neukladať"
 
 msgid "Don’t Save"
 msgstr "Neukladať"

--- a/locales/sl.po
+++ b/locales/sl.po
@@ -435,8 +435,8 @@ msgstr "Če opravljenih sprememb ne shranite, bodo trajno izgubljene."
 msgid "Save"
 msgstr "Shrani"
 
-msgid "Don’t save"
-msgstr "Ne shrani"
+msgid "Do&n’t save"
+msgstr "&Ne shrani"
 
 msgid "Don’t Save"
 msgstr "Ne shrani"

--- a/locales/sq.po
+++ b/locales/sq.po
@@ -437,7 +437,7 @@ msgstr "Ndryshimet tuaja do të humbasin, nëse s’i ruani."
 msgid "Save"
 msgstr "Ruaje"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Mos e ruaj"
 
 msgid "Don’t Save"

--- a/locales/sr.po
+++ b/locales/sr.po
@@ -430,7 +430,7 @@ msgstr "Измене ће бити изгубљене ако их не сачу�
 msgid "Save"
 msgstr "&Сачувај"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Не чувај"
 
 msgid "Don’t Save"

--- a/locales/sv.po
+++ b/locales/sv.po
@@ -434,7 +434,7 @@ msgstr "Dina ändringar går förlorade om du inte sparar dem."
 msgid "Save"
 msgstr "Spara"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Spara inte"
 
 msgid "Don’t Save"

--- a/locales/tg.po
+++ b/locales/tg.po
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Save"
 msgstr "Захира кардан"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/th.po
+++ b/locales/th.po
@@ -416,7 +416,7 @@ msgstr ""
 msgid "Save"
 msgstr "บันทึก"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -433,7 +433,7 @@ msgstr "Kaydetmezseniz yaptığınız değişiklikler kaybolacak."
 msgid "Save"
 msgstr "Kaydet"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Kaydetme"
 
 msgid "Don’t Save"

--- a/locales/uk.po
+++ b/locales/uk.po
@@ -437,7 +437,7 @@ msgstr "Внесені зміни буде втрачено, якщо їх не 
 msgid "Save"
 msgstr "Зберегти"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Не зберігати"
 
 msgid "Don’t Save"

--- a/locales/uz.po
+++ b/locales/uz.po
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Save"
 msgstr "Saqlash"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr ""
 
 msgid "Don’t Save"

--- a/locales/vi.po
+++ b/locales/vi.po
@@ -425,7 +425,7 @@ msgstr "Các thay đổi của bạn sẽ bị mất nếu bạn không lưu ch�
 msgid "Save"
 msgstr "Lưu"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "Không lưu"
 
 msgid "Don’t Save"

--- a/locales/zh_CN.po
+++ b/locales/zh_CN.po
@@ -421,7 +421,7 @@ msgstr "如果您不保存，您的更改将丢失。"
 msgid "Save"
 msgstr "保存"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "不保存"
 
 msgid "Don’t Save"

--- a/locales/zh_TW.po
+++ b/locales/zh_TW.po
@@ -421,7 +421,7 @@ msgstr "如果不儲存，會失去您所做過的變更。"
 msgid "Save"
 msgstr "儲存"
 
-msgid "Don’t save"
+msgid "Do&n’t save"
 msgstr "不要儲存"
 
 msgid "Don’t Save"

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1016,7 +1016,7 @@ wxWindowPtr<wxMessageDialog> PoeditFrame::CreateAskAboutSavingDialog()
          (
             _("Save"),
         #ifdef __WXMSW__
-            _(L"Don’t save")
+            _(L"Do&n’t save")
         #else
             _(L"Don’t Save")
         #endif


### PR DESCRIPTION
In the dialogue that opens when quiting Poedit (`PoeditFrame::CreateAskAboutSavingDialog`). Since I only have Windows to test it on, I didn't touch the other platforms.

This pull request allows users to press "n" when prompted if they want to save.

Fixes #459