### PR TITLE
Update appstream data to components version 0.11

### DIFF
--- a/poedit.appdata.xml
+++ b/poedit.appdata.xml
@@ -1,35 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<application>
-  <id type="desktop">poedit.desktop</id>
-  <metadata_license>CC0-1.0</metadata_license>
-  <project_license>MIT</project_license>
-  <name>Poedit</name>
-  <summary>GUI editor for GNU gettext .po files</summary>
-  <summary xml:lang="de">Grafischer Editor für GNU Gettext-Dateien</summary>
-  <description>
-    <p>
-      This program is a GUI frontend to GNU Gettext utilities and a catalogs 
-      editor/source code parser. It helps with translating applications into 
-      other languages.
-    </p>
-    <p xml:lang="de">
-      Dieses Programm stellt eine grafische Benutzeroberfläche für die
+<?xml version="1.0" encoding="utf-8"?>
+<components version="0.11">
+  <component type="desktop-application">
+    <id>poedit.desktop</id>
+    <name>Poedit</name>
+    <summary>GUI editor for GNU gettext .po files</summary>
+    <project_license>MIT</project_license>
+    <description>
+      <p>This program is a GUI frontend to GNU Gettext utilities and a catalogs
+      editor/source code parser. It helps with translating applications into
+      other languages.</p>
+    </description>
+    <description xml:lang="de">
+      <p>Dieses Programm stellt eine grafische Benutzeroberfläche für die
       Dienstprogramme aus GNU Gettext bereit, sowie einen Katalogeditor und
       einen Quellcode-Parser. Es hilft beim Übersetzen von Anwendungen in
-      andere Sprachen.
-    </p>
-  </description>
-  <screenshots>
-    <screenshot type="default">
-      <image>https://upload.wikimedia.org/wikipedia/commons/c/c2/Poedit_1.8.1_en.png</image>
-    </screenshot>
-  </screenshots>
-  <url type="homepage">https://poedit.net</url>
-  <url type="translate">https://crowdin.com/project/poedit</url>
-  <updatecontact>help@poedit.net</updatecontact>
-  <keywords>
-   <keyword>translation</keyword>
-   <keyword>gettext</keyword>
-   <keyword>wordpress</keyword>
-  </keywords>
-</application>
+      andere Sprachen.</p>
+    </description>
+    <screenshots>
+      <screenshot>
+        <image type="source">https://upload.wikimedia.org/wikipedia/commons/c/c2/Poedit_1.8.1_en.png</image>
+      </screenshot>
+    </screenshots>
+    <url type="homepage">https://poedit.net</url>
+    <url type="translate">https://crowdin.com/project/poedit</url>
+    <keywords>
+      <keyword>translation</keyword>
+      <keyword>gettext</keyword>
+      <keyword>wordpress</keyword>
+    </keywords>
+  </component>
+</components>


### PR DESCRIPTION
This updates the appdata file to components version 0.11 - the one problem still in this version is the id field - running

appstreamcli validate poedit.appdata.xml

gives:

W - poedit.appdata.xml:poedit:4
    The component ID is not a reverse domain-name. Please update the ID and that of 
    the accompanying .desktop file to follow the latest version of the Desktop-Entry 
    and AppStream specifications and avoid future issues.

