### PR TITLE
Implement EditorConfig(http://editorconfig.org)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.sh]
+end_of_line = lf
+
+[*.{sln,vcproj,vcxproj*}]
+end_of_line = crlf
+
+[/.gitmodules]
+indent_style = tab
+end_of_line = lf


### PR DESCRIPTION
"EditorConfig helps developers define and maintain consistent coding
 styles between different editors and IDEs."

This patch implments a simple EditorConfig to force tab indentation
on /.gitmodules in complying editors.  It also copied some existing
rules in .gitattributes.

Refer-to: EditorConfig <http://editorconfig.org>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>