### PR TITLE
Use specific name of dependency Compact Language Detector 2

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@ Requirements:
 
 Optional dependencies:
 
-  * cld2 (better language autodetection and non-English source languages)
+  * libcld2-dev ("Compact Language Detector 2" for better language autodetection and non-English source languages)
   * C++REST SDK >= 2.5 (Crowdin integration)
 
 


### PR DESCRIPTION
So it's easier to find and install by package managers like apt.