### PR TITLE
Travis: Incorporate Compiler cache(ccache)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ addons:
             - libsecret-1-dev
 
 env:
-    - REAL_CC=gcc-6 REAL_CXX=g++-6
+    - REAL_CC='ccache gcc-6' REAL_CXX='ccache g++-6'
 
 before_install:
     # work around Travis being difficult, see https://github.com/travis-ci/travis-ci/issues/6633
-    - export CC=$REAL_CC CXX=$REAL_CXX
+    - export CC="$REAL_CC" CXX="$REAL_CXX"
     # git submodules needed for Linux:
     - git submodule update --init deps/json deps/pugixml
 
@@ -53,7 +53,9 @@ after_failure:
 git:
     submodules: false
 
-cache: apt
+cache:
+    apt: true
+    ccache: true
 
 deploy:
     provider: releases


### PR DESCRIPTION
This patch enables ccache caching for a faster rebuild.

Without cache:

![09](https://user-images.githubusercontent.com/13408130/41163588-ad0955ce-6b6b-11e8-95aa-159ce92ab0d9.png)

The build time increases about 90 seconds more than when ccache is not enabled(approx. 11m50s).

With existing cache([log](https://travis-ci.com/Lin-Buo-Ren/poedit/jobs/128351224)):

![10](https://user-images.githubusercontent.com/13408130/41163589-add9bffc-6b6b-11e8-8582-31364679c6f2.png)

the build time dropped to about 7 minutes.

The build results in a 35.38MiB of cache data, it *might* be sane to further restrict ccache size to 50MiB to avoid constantly increasing cache size in subsequent builds(by default the cache size limit is 5.0GiB)

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>