### PR TITLE
Drop ccache from snap build and minor fixes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,7 +81,6 @@ parts:
   poedit:
     after:
       - boostlib
-      - ccache
       - gtkspell
       - patches
       - wxwidgets
@@ -131,9 +130,6 @@ parts:
     plugin: autotools
     override-build: |
       set -eu
-
-      # Setup ccache + GCC-6
-      PATH="${SNAPCRAFT_STAGE}/bin:${PATH}"
 
       ./bootstrap
       ./configure \
@@ -211,9 +207,6 @@ parts:
       - no-system-libraries
 
   boostlib:
-    after:
-      - ccache
-
     source: deps/boost
 
     build-packages:
@@ -226,9 +219,6 @@ parts:
     plugin: dump
     override-build: |
       set -eu
-
-      # Setup ccache + GCC-6
-      PATH="${SNAPCRAFT_STAGE}/bin:${PATH}"
 
       ./bootstrap.sh \
         --prefix="${SNAPCRAFT_PART_INSTALL}" \
@@ -252,9 +242,6 @@ parts:
     override-prime: 'true'
 
   wxwidgets:
-    after:
-      - ccache
-
     source: deps/wx
 
     build-packages:
@@ -284,9 +271,6 @@ parts:
     plugin: autotools
     override-build: |
       set -eu
-
-      # Setup ccache + GCC-6
-      PATH="${SNAPCRAFT_STAGE}/bin:${PATH}"
 
       ./autogen.sh
       ./configure \
@@ -348,52 +332,8 @@ parts:
       - $files-from-stage-packages
       - $localizations
 
-  # This pseudo part setups Compiler cache(ccache) to the stage dir.
-  #
-  # To use it simply add a dependency to this part and prepend
-  # "$SNAPCRAFT_STAGE"/bin to the command search PATHs
-  ccache:
-    after:
-      - gcc-6
-    override-pull: 'true'
-    build-packages:
-      - ccache
-    plugin: nil
-    override-build: |
-      mkdir \
-        --parents \
-        "${SNAPCRAFT_PART_INSTALL}"/bin
-      ln \
-        --force \
-        --symbolic \
-        "$(which ccache)" \
-        "${SNAPCRAFT_PART_INSTALL}"/bin/gcc-6
-      ln \
-        --force \
-        --symbolic \
-        "$(which ccache)" \
-        "${SNAPCRAFT_PART_INSTALL}"/bin/g++-6
-      ln \
-        --force \
-        --symbolic \
-        ./gcc-6 \
-        "${SNAPCRAFT_PART_INSTALL}"/bin/gcc
-      ln \
-        --force \
-        --symbolic \
-        ./g++-6 \
-        "${SNAPCRAFT_PART_INSTALL}"/bin/g++
-    filesets:
-      executables:
-        - bin/*
-    stage:
-      - $executables
-    override-prime: 'true'
-
   # This pseudo part setups version 6 of GCC, which is not available
   # in Ubuntu 16.04 software source.
-  # To use it simply add a dependency to this part and prepend
-  # "$SNAPCRAFT_STAGE"/bin to the command search PATHs
   gcc-6:
     plugin: nil
     # Poedit sources will be used when `source` is ommitted, avoid this
@@ -407,34 +347,31 @@ parts:
       sudo apt update
       sudo apt --yes install cpp-6 gcc-6 g++-6
 
+    override-stage: |
+      set -eu
+
       # Make fake executable search path for build systems that don't
       # respect CC and CXX environmental variables
+      # Snapcraft will give executable paths under SNAPCRAFT_STAGE priority
+      # in other parts' build step
       mkdir \
         --parents \
-        "${SNAPCRAFT_PART_INSTALL}"/bin
-      # DISABLED: Replaced by ccache-gcc-6
-      #ln \
-        #--force \
-        #--symbolic \
-        #"$(which gcc-6)" \
-        #"${SNAPCRAFT_PART_INSTALL}"/bin/gcc
-      #ln \
-        #--force \
-        #--symbolic \
-        #"$(which g++-6)" \
-        #"${SNAPCRAFT_PART_INSTALL}"/bin/g++
+        "${SNAPCRAFT_STAGE}"/bin
+      ln \
+        --force \
+        --symbolic \
+        "$(which gcc-6)" \
+        "${SNAPCRAFT_STAGE}"/bin/gcc
+      ln \
+        --force \
+        --symbolic \
+        "$(which g++-6)" \
+        "${SNAPCRAFT_STAGE}"/bin/g++
       ln \
         --force \
         --symbolic \
         "$(which cpp-6)" \
-        "${SNAPCRAFT_PART_INSTALL}"/bin/cpp
-
-    filesets:
-      executables:
-        - bin/*
-    stage:
-      - $executables
-    override-prime: 'true'
+        "${SNAPCRAFT_STAGE}"/bin/cpp
 
   spellcheck-dictionaries:
     plugin: nil
@@ -477,7 +414,6 @@ parts:
   # to fix the non-relocatable iso-codes data path.
   gtkspell:
     after:
-      - ccache
       - enchant
       - iso-codes
 
@@ -506,9 +442,6 @@ parts:
       - valac
     override-build: |
       set -eu
-
-      # Setup ccache + GCC-6
-      PATH="${SNAPCRAFT_STAGE}/bin:${PATH}"
 
       # autogen.sh requires build directory to be created in advance
       # https://sourceforge.net/p/gtkspell/gtkspell/merge-requests/1/
@@ -561,7 +494,6 @@ parts:
   #    patches/enchant-fix-build.patch for details
   enchant:
     after:
-      - ccache
       - patches
 
     source: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
@@ -583,9 +515,6 @@ parts:
 
     override-build: |
       set -eu
-
-      # Setup ccache + GCC-6
-      PATH="${SNAPCRAFT_STAGE}/bin:${PATH}"
 
       env NOCONFIGURE=yes ./autogen.sh
       ./configure \


### PR DESCRIPTION
Ccache is originally incorporated as a measure to speed up the rebuild
process(to determine whether the recipe works), as the packaging is nearly
completed it is no longer that useful but complicates the recipe.

This patch drops the ccache part and also changes the behavior of the
gcc-6 recipe to create the faked GCC commands symbolic links at stage
phase instead of build phase for Docker + MacOS filesystem compatibility.

This patch also drops the assignment of SNAPCRAFT_STAGE/bin from the
command search PATHs as it is already done by Snapcraft.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>