### PR TITLE
Drop XDG_DATA_DIRS workaround from snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,8 +26,6 @@ apps:
     # WORKAROUND: Fix icon loading problem
     # https://github.com/ubuntu/snapcraft-desktop-helpers/pull/121
     command: >
-      env
-      XDG_DATA_DIRS="$SNAP/share:$XDG_DATA_DIRS"
       desktop-launch poedit
     desktop: share/applications/poedit.desktop
     plugs:
@@ -61,8 +59,6 @@ apps:
 
   poedit-uri-handler:
     command: >
-      env
-      XDG_DATA_DIRS="$SNAP/share:$XDG_DATA_DIRS"
       desktop-launch poedit
     desktop: share/applications/poedit-uri.desktop
     plugs:


### PR DESCRIPTION
The fix is already merged upstream thus no longer to be workarounded.

Prepend $SNAP/share to XDG_DATA_DIRS · ubuntu/snapcraft-desktop-helpers
https://github.com/ubuntu/snapcraft-desktop-helpers/pull/121