### PR TITLE
Use the null parts syntax for desktop-gtk3 part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,6 @@ parts:
       - gtkspell
       - patches
       - wxwidgets
-      - desktop-gtk3
 
     source: .
 
@@ -192,6 +191,8 @@ parts:
 
     build-attributes:
       - no-system-libraries
+
+  desktop-gtk3:
 
   boostlib:
     after:


### PR DESCRIPTION
Prefer this new syntax introduced in Snapcraft 2.43 to avoid the
cleaning of the poedit part due to the modification of the
desktop-gtk3 part.

Refer: https://github.com/snapcore/snapcraft/pull/2153