### PR TITLE
Workaround snapcraft's implicit source 'feature'

### DIFF
--- a/snap/local/empty/README
+++ b/snap/local/empty/README
@@ -1,0 +1,23 @@
+This is an empty source directory to workaround a snapcraft 'feature' 
+where parts using the nil plugin are implicitly considered to use `.` 
+as an implicit source directory.
+
+This avoids the entire source tree being unnecessarily copied as the 
+part's source tree.
+
+This also avoids the nil parts being considered 'changed' by snapcraft 
+whenever a file in the source tree is modified, causing all depending 
+parts' artifacts being cleaned by snapcraft.
+
+Refer the following snapcraft forum topics for more details:
+
+    Bug #1776807 “`nil` plugin shouldn't pull anything to the srctree” 
+: Bugs : Snapcraft
+    https://bugs.launchpad.net/snapcraft/+bug/1776807
+    
+    Remote part considered as "source changed" - snapcraft - 
+snapcraft.io    
+    https://forum.snapcraft.io/t/remote-part-considered-as-source-changed/8606/5
+
+    Snapcraft implicit source - snapcraft - snapcraft.io
+    https://forum.snapcraft.io/t/snapcraft-implicit-source/7060

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -332,7 +332,7 @@ parts:
   ccache:
     after:
       - gcc-6
-    override-pull: 'true'
+    source: snap/local/empty
     build-packages:
       - ccache
     plugin: nil
@@ -370,10 +370,8 @@ parts:
   # This pseudo part setups version 6 of GCC, which is not available
   # in Ubuntu 16.04 software source.
   gcc-6:
+    source: snap/local/empty
     plugin: nil
-    # Poedit sources will be used when `source` is ommitted, avoid this
-    # behavior
-    override-pull: 'true'
     override-build: |
       sudo apt --yes install software-properties-common
 
@@ -414,10 +412,8 @@ parts:
     override-prime: 'true'
 
   spellcheck-dictionaries:
+    source: snap/local/empty
     plugin: nil
-    # Poedit sources will be used when `source` is ommitted, avoid this
-    # behavior
-    override-pull: 'true'
     override-build: |
       set -eu
 
@@ -591,8 +587,7 @@ parts:
   # This patch slightly patches iso-codes's pkg-config so that non-
   # relocable GtkSpell part can locate its data
   iso-codes:
-    override-pull: 'true'
-
+    source: snap/local/empty
     plugin: nil
     override-build: |
       set -eu


### PR DESCRIPTION
Snapcraft will implicitly set a part's `source` as `.`(the directory
running the `snapcraft` command) when its `source` key is not set,
this causes the following problems:

* The entire source tree being copied to the part's srcdir
  (which is previously workarounded using `override-pull` scriptlets)
* The parts that using the `nil` plugin(parts without a source) are
  considered 'changed' whenever any file in the source tree is modified
  , causing all depending parts cleaned and rebuild by snapcraft.

This patch workaround it differently by using the snap/local/empty dummy
folder as these parts' `source` thus avoid the problems.