### PR TITLE
Change dir for the appdata.xml to metainfo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,8 @@ SUBDIRS = src docs locales artwork
 desktopdir=$(datadir)/applications
 dist_desktop_DATA = net.poedit.Poedit.desktop net.poedit.PoeditURI.desktop
 
-appdatadir=$(datadir)/appdata
-dist_appdata_DATA = net.poedit.Poedit.appdata.xml
+metainfodir=$(datadir)/metainfo
+dist_metainfo_DATA = net.poedit.Poedit.appdata.xml
 
 EXTRA_DIST = \
 	deps/json/LICENSE.MIT \


### PR DESCRIPTION
The default directory for the appdata xml file changed from appdata to metainfo, as can be seen in https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent

> Upstream projects can ship one or more metainfo files in /usr/share/metainfo/%{id}.metainfo.xml, where id is a unique identifier of this specific component.
> ...
> AppStream tools scan the /usr/share/appdata/ path for legacy compatibility as well. It should not be used anymore by new software though, ...

This commit changes the data installation directory in the from `share/appdata` to `share/metainfo`.

p.s.: I didn't change the filename replacing `...appdata.xml` -> `...metainfo.xml` as I notice almost all apps installed in my system didn't change it. Let me know if you want me to change and I'll commit & squash it.