### PR TITLE
Snapcraft: simplify $prefix/share files packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -165,30 +165,17 @@ parts:
         - bin/*
       files-in-stage-packages:
         - usr/*
-      freedesktop-desktop-entries:
-        - share/applications/*
-      localizations:
-        - share/locale/*
-      manpages:
-        - share/man/*
       resources:
-        - share/icons/*
-        - share/poedit/*
+        - share/*
 
     stage:
       - $executables
       - $files-in-stage-packages
-      - $freedesktop-desktop-entries
-      - $localizations
-      - $manpages
       - $resources
 
     prime:
       - $executables
       - $files-in-stage-packages
-      - $freedesktop-desktop-entries
-      - $localizations
-      - $manpages
       - $resources
 
     build-attributes:


### PR DESCRIPTION
No reason to split share content into multiple entries (and accidentally omit some), just package the entire `share/` directory.

Motivation: b3b28e047b4ceb18943fca6ea6ba97b305fccb76, similarly appdata files are accidentally not packages (but probably not useful).

@Lin-Buo-Ren can you see any problem with this simplification, i.e. could it possibly pull in some junk from other parts? TIA!