### PR TITLE
Add header for LearnMoreLink.

### DIFF
--- a/src/welcomescreen.cpp
+++ b/src/welcomescreen.cpp
@@ -26,6 +26,7 @@
 #include "welcomescreen.h"
 
 #include "colorscheme.h"
+#include "customcontrols.h"
 #include "crowdin_gui.h"
 #include "edapp.h"
 #include "edframe.h"


### PR DESCRIPTION
Fixes
welcomescreen.cpp: In constructor 'EmptyPOScreenPanel::EmptyPOScreenPanel(PoeditFrame*)':
welcomescreen.cpp:289:26: error: 'LearnMoreLink' does not name a type; did you mean 'learnMore'?
     auto learnMore = new LearnMoreLink(this, "http://www.gnu.org/software/gettext/manual/html_node/", _("(Learn more about GNU gettext)"));
                          ^~~~~~~~~~~~~
                          learnMore
