### PR TITLE
README: Add Debian/Ubuntu compilation instructions

### DIFF
--- a/README
+++ b/README
@@ -54,7 +54,14 @@ Do the usual thing:
     make install
 
 You must have the dependencies installed in a location where configure will find
-them, e.g. by setting CPPFLAGS and LDFLAGS appropriately.
+them, e.g. by setting CPPFLAGS and LDFLAGS appropriately. For example, to install
+and setup all required dependencies in Debian Buster, you can run the following:
+
+    apt install libboost-all-dev libwxgtk3.0-dev libgtkspell-dev liblucene++-dev
+    
+Other optional dependencies can also be installed using apt-get:
+
+    apt install libcpprest-dev libsecret-1-dev nlohmann-json3-dev libcanberra-gtk-module
 
 
  macOS


### PR DESCRIPTION
I had to install the following to get rid of most warnings when running `./configure`.

I guess `build-essential` package was also required.