### PR TITLE
Use wxGETTEXT_IN_CONTEXT() for "Needs work"

### DIFF
--- a/locales/Makefile.am
+++ b/locales/Makefile.am
@@ -28,6 +28,7 @@ XARGS=xargs
 
 # common xgettext args: C++ syntax, use the specified macro names as markers
 XGETTEXT_ARGS=-C -k_ -kwxGetTranslation -kwxTRANSLATE -kwxPLURAL:1,2 -F -j \
+              -kwxGETTEXT_IN_CONTEXT:1c,2 -kwxGETTEXT_IN_CONTEXT_PLURAL:1c,2,3 \
               --add-comments=TRANSLATORS \
               --from-code=UTF-8 \
               --package-name=Poedit --package-version=$(PACKAGE_VERSION) \

--- a/scripts/refresh-pot.sh
+++ b/scripts/refresh-pot.sh
@@ -5,6 +5,7 @@ PACKAGE_VERSION=2.1
 [ -n "${WXRC}" ] || WXRC=wxrc
 
 XGETTEXT_ARGS="-C -k_ -kwxGetTranslation -kwxTRANSLATE -kwxPLURAL:1,2 -F \
+              -kwxGETTEXT_IN_CONTEXT:1c,2 -kwxGETTEXT_IN_CONTEXT_PLURAL:1c,2,3 \
               --add-comments=TRANSLATORS \
               --from-code=UTF-8 \
               --package-name=Poedit --package-version=${PACKAGE_VERSION} \

--- a/src/editing_area.cpp
+++ b/src/editing_area.cpp
@@ -453,7 +453,9 @@ void EditingArea::CreateEditControls(wxBoxSizer *sizer)
     // "needs review" implies that somebody else should review the string after
     // I am done with it (i.e. consider it good), while "needs work" implies I
     // need to return to it and finish the translation.
-    m_fuzzy = new SwitchButton(this, wxID_ANY, MSW_OR_OTHER(_("Needs work"), _("Needs Work")));
+    m_fuzzy = new SwitchButton(this, wxID_ANY,
+        MSW_OR_OTHER(wxGETTEXT_IN_CONTEXT("editing_area", "Needs work"),
+        wxGETTEXT_IN_CONTEXT("editing_area", "Needs Work")));
 #ifdef __WXOSX__
     m_fuzzy->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 #endif

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -271,7 +271,7 @@ void ManagerFrame::UpdateListCat(int id)
     m_listCat->InsertColumn(0, _("Catalog"));
     m_listCat->InsertColumn(1, _("Total"));
     m_listCat->InsertColumn(2, _("Untrans"));
-    m_listCat->InsertColumn(3, _("Needs Work"));
+    m_listCat->InsertColumn(3, wxGETTEXT_IN_CONTEXT("manager", "Needs Work"));
     m_listCat->InsertColumn(4, _("Errors"));
     m_listCat->InsertColumn(5, _("Last modified"));
 


### PR DESCRIPTION
Take advantage of wxWidgets 3.1.1's support for translation contexts
and use it for "Needs Work"/"Needs work".

This very string has been troublesome with Finnish, as the translation
would need to be different in the editing area and in statistics.

There's probably one more "Needs work" entry in the closed-source statistics page.

(This commit message is just a placeholder explaining what the commit does and why.
I am confident I couldn't write a commit message that satisfies you anyway, so feel free to
rephrase.)