### PR TITLE
Crowdin API v2, OAuth v2, open/save/sync as Xliff all files with translations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "deps/pugixml"]
 	path = deps/pugixml
 	url = https://github.com/zeux/pugixml.git
+[submodule "deps/jwt-cpp"]
+	path = deps/jwt-cpp
+	url = https://github.com/Thalhammer/jwt-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "deps/jwt-cpp"]
 	path = deps/jwt-cpp
 	url = https://github.com/Thalhammer/jwt-cpp.git
+[submodule "deps/openssl"]
+	path = deps/openssl
+	url = https://github.com/openssl/openssl.git

--- a/Poedit.vcxproj
+++ b/Poedit.vcxproj
@@ -52,7 +52,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>HAVE_CLD2;HAVE_HTTP_CLIENT;XML_STATIC;_NO_ASYNCRTIMP;WIN32;_DEBUG;DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;deps\custom_build\config;deps\wx\include;deps\boost;deps\winsparkle\include;deps\lucene;deps\lucene\LucenePlusPlus\include;deps\cld2;deps\icu4c\include;deps\icu4c\source\i18n;deps\casablanca\Release\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;deps\custom_build\config;deps\wx\include;deps\boost;deps\winsparkle\include;deps\lucene;deps\lucene\LucenePlusPlus\include;deps\cld2;deps\icu4c\include;deps\icu4c\source\i18n;deps\casablanca\Release\include;deps\jwt-cpp\include;deps\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <DisableSpecificWarnings>4800</DisableSpecificWarnings>
@@ -82,7 +82,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>HAVE_CLD2;HAVE_HTTP_CLIENT;XML_STATIC;_NO_ASYNCRTIMP;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;deps\custom_build\config;deps\wx\include;deps\boost;deps\winsparkle\include;deps\lucene;deps\lucene\LucenePlusPlus\include;deps\cld2;deps\icu4c\include;deps\icu4c\source\i18n;deps\casablanca\Release\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;deps\custom_build\config;deps\wx\include;deps\boost;deps\winsparkle\include;deps\lucene;deps\lucene\LucenePlusPlus\include;deps\cld2;deps\icu4c\include;deps\icu4c\source\i18n;deps\casablanca\Release\include;deps\jwt-cpp\include;deps\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4800</DisableSpecificWarnings>
       <PrecompiledHeaderFile>Poedit-Prefix.pch</PrecompiledHeaderFile>

--- a/Poedit.xcodeproj/project.pbxproj
+++ b/Poedit.xcodeproj/project.pbxproj
@@ -1757,6 +1757,8 @@
 					deps/lucene/LucenePlusPlus/include,
 					deps/cld2,
 					deps/AFNetworking/AFNetworking,
+					deps/openssl/include,
+					"deps/jwt-cpp/include",
 					"$(DEPS_BUILD_DIR)/icu/include",
 				);
 				LIBRARY_SEARCH_PATHS = "$(DEPS_BUILD_DIR)/icu/lib";
@@ -1829,6 +1831,8 @@
 					deps/lucene/LucenePlusPlus/include,
 					deps/cld2,
 					deps/AFNetworking/AFNetworking,
+					"deps/jwt-cpp/include",
+					deps/openssl/include,
 					"$(DEPS_BUILD_DIR)/icu/include",
 				);
 				LIBRARY_SEARCH_PATHS = "$(DEPS_BUILD_DIR)/icu/lib";

--- a/Poedit.xcodeproj/project.pbxproj
+++ b/Poedit.xcodeproj/project.pbxproj
@@ -1757,7 +1757,7 @@
 					deps/lucene/LucenePlusPlus/include,
 					deps/cld2,
 					deps/AFNetworking/AFNetworking,
-					deps/openssl/include,
+					deps/openssl/boringssl/include,
 					"deps/jwt-cpp/include",
 					"$(DEPS_BUILD_DIR)/icu/include",
 				);
@@ -1831,8 +1831,8 @@
 					deps/lucene/LucenePlusPlus/include,
 					deps/cld2,
 					deps/AFNetworking/AFNetworking,
+					deps/openssl/boringssl/include,
 					"deps/jwt-cpp/include",
-					deps/openssl/include,
 					"$(DEPS_BUILD_DIR)/icu/include",
 				);
 				LIBRARY_SEARCH_PATHS = "$(DEPS_BUILD_DIR)/icu/lib";

--- a/README
+++ b/README
@@ -97,7 +97,7 @@ cloning the repository, run the following command:
 On Linux and other Unices, only a subset of submodules is necessary, so you can
 save some time and disk space by checking out only them:
 
-    git submodule update --init deps/json deps/pugixml
+    git submodule update --init deps/json deps/pugixml deps/jwt-cpp
 
 When building for Unix/Linux, if you get the sources directly from the Git
 repository, some generated files are not present. You have to run the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,3 +97,5 @@ compiled_xrc.cpp: $(XRC_RESOURCES)
 DISTCLEANFILES = $(nodist_poedit_SOURCES)
 
 EXTRA_DIST = $(XRC_RESOURCES) pluralforms/COPYING
+
+AM_CPPFLAGS = -I../deps/jwt-cpp/include

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -597,6 +597,9 @@ void Catalog::SetFileName(const wxString& fn)
 {
     wxFileName f(fn);
     f.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE);
+    auto name = f.GetName();
+    name.ToLong(&m_crowdinProjectId);
+    name.AfterFirst('_').ToLong(&m_crowdinFileId);
     m_fileName = f.GetFullPath();
 }
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -469,7 +469,7 @@ class Catalog
         Type GetFileType() const { return m_fileType; }
 
         wxString GetFileName() const { return m_fileName; }
-        void SetFileName(const wxString& fn);
+        virtual void SetFileName(const wxString& fn);
 
         /**
             Return base path to source code for extraction, or empty string if not configured.
@@ -552,9 +552,10 @@ class Catalog
         virtual void SetLanguage(Language lang);
 
         /// Is the PO file from Crowdin, i.e. sync-able?
-        bool IsFromCrowdin() const
-            { return m_header.HasHeader("X-Crowdin-Project") && m_header.HasHeader("X-Crowdin-File"); }
-
+        bool IsFromCrowdin() const { return m_crowdinFileId > 0 && m_crowdinProjectId > 0; }
+        long GetCrowdinFileId() const { return m_crowdinFileId; }
+        long GetCrowdinProjectId() const { return m_crowdinProjectId; }
+            
         /// Returns true if the catalog contains obsolete entries (~.*)
         virtual bool HasDeletedItems() const = 0;
 
@@ -594,6 +595,7 @@ class Catalog
         bool m_isOk;
         Type m_fileType;
         wxString m_fileName;
+        long m_crowdinFileId = -1, m_crowdinProjectId = -1;
         HeaderData m_header;
         Language m_sourceLanguage;
 

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -403,6 +403,7 @@ std::shared_ptr<XLIFFCatalog> XLIFFCatalog::Open(const wxString& filename)
     else
         throw XLIFFReadException(filename, wxString::Format(_("unsupported XLIFF version (%s)"), xliff_version));
 
+    cat->SetFileName(filename);
     cat->Parse(xliff_root);
 
     return cat;

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -33,6 +33,7 @@
 
 #include <wx/intl.h>
 #include <wx/log.h>
+#include <wx/stdpaths.h>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -609,7 +609,8 @@ void XLIFF1Catalog::Parse(pugi::xml_node root)
         //       (what is always the only case for downloaded from Crowdin)
         //       But should be taken into account and improved for probable
         //       more wide varietty of cases in the future.
-        if(id == 0) {
+        if(id == 0)
+        {
             m_sourceLanguage = Language::TryParse(file.attribute("source-language").value());
             SetLanguage(Language::TryParse(file.attribute("target-language").value()));
         }

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -29,6 +29,7 @@
 #include "configuration.h"
 #include "str_helpers.h"
 #include "utility.h"
+#include "crowdin_gui.h"
 
 #include <wx/intl.h>
 #include <wx/log.h>
@@ -378,7 +379,6 @@ bool XLIFFCatalog::CanLoadFile(const wxString& extension)
     return extension == "xlf" || extension == "xliff";
 }
 
-
 std::shared_ptr<XLIFFCatalog> XLIFFCatalog::Open(const wxString& filename)
 {
     constexpr auto parse_flags = parse_full | parse_ws_pcdata | parse_fragment;
@@ -595,14 +595,23 @@ public:
     }
 };
 
-
 void XLIFF1Catalog::Parse(pugi::xml_node root)
 {
     int id = 0;
+    
     for (auto file: root.children("file"))
     {
-        m_sourceLanguage = Language::TryParse(file.attribute("source-language").value());
-        m_language = Language::TryParse(file.attribute("target-language").value());
+        // TODO: Only first `file` node atthributes are used for now
+        //       what works well in case of either all next are same within
+        //       same `xliff` or if the only single `file` node is there
+        //       (what is always the only case for downloaded from Crowdin)
+        //       But should be taken into account and improved for probable
+        //       more wide varietty of cases in the future.
+        if(id == 0) {
+            m_sourceLanguage = Language::TryParse(file.attribute("source-language").value());
+            SetLanguage(Language::TryParse(file.attribute("target-language").value()));
+        }
+        
         for (auto unit: file.select_nodes(".//trans-unit"))
         {
             auto node = unit.node();
@@ -737,7 +746,7 @@ protected:
 void XLIFF2Catalog::Parse(pugi::xml_node root)
 {
     m_sourceLanguage = Language::TryParse(root.attribute("srcLang").value());
-    m_language = Language::TryParse(root.attribute("trgLang").value());
+    SetLanguage(Language::TryParse(root.attribute("trgLang").value()));
 
     int id = 0;
     for (auto segment: root.select_nodes(".//segment"))

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -29,11 +29,11 @@
 #include "configuration.h"
 #include "str_helpers.h"
 #include "utility.h"
-#include "crowdin_gui.h"
 
 #include <wx/intl.h>
 #include <wx/log.h>
 #include <wx/stdpaths.h>
+#include <wx/utils.h>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/catalog_xliff.h
+++ b/src/catalog_xliff.h
@@ -27,6 +27,7 @@
 #define Poedit_catalog_xliff_h
 
 #include "catalog.h"
+#include "cloud_sync.h"
 #include "errors.h"
 
 #include "pugixml.h"
@@ -101,9 +102,6 @@ public:
 
     ValidationResults Validate(bool wasJustLoaded) override;
 
-    Language GetLanguage() const override { return m_language; }
-    void SetLanguage(Language lang) override { m_language = lang; }
-
     // FIXME: PO specific
     bool HasDeletedItems() const override { return false;}
     void RemoveDeletedItems() override {}
@@ -118,7 +116,6 @@ protected:
 
 protected:
     pugi::xml_document m_doc;
-    Language m_language;
 };
 
 

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -83,6 +83,26 @@ public:
 
         return std::make_shared<Dest>(name, std::move(func));
     }
+
+    static const wxString& GetCacheDir()
+    {
+        static wxString localBaseDir;
+
+        if(localBaseDir.empty()) {
+
+            #if defined(__WXOSX__)
+                localBaseDir = wxGetHomeDir() + "/Library/Caches/net.poedit.Poedit";
+            #elif defined(__UNIX__)
+                if (!wxGetEnv("XDG_CACHE_HOME", &localBaseDir))
+                    localBaseDir = wxGetHomeDir() + "/.cache";
+                localBaseDir += "/poedit";
+            #else
+                localBaseDir = wxStandardPaths::Get().GetUserDataDir() + wxFILE_SEP_PATH + "Cache";
+            #endif
+        }
+
+        return localBaseDir;
+    }
 };
 
 

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -89,7 +89,8 @@ public:
     {
         static wxString localBaseDir;
 
-        if(localBaseDir.empty()) {
+        if(localBaseDir.empty())
+        {
 
             #if defined(__WXOSX__)
                 localBaseDir = wxGetHomeDir() + "/Library/Caches/net.poedit.Poedit";
@@ -137,7 +138,8 @@ public:
     /// Show the window while performing background sync action. Show error if 
     static void RunSync(wxWindow *parent, std::shared_ptr<CloudSyncDestination> dest, CatalogPtr file)
     {
-        if(!dest->Auth(parent)) {
+        if(!dest->Auth(parent))
+        {
             return;
         }
 

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -62,6 +62,7 @@ public:
 
     /// Asynchronously uploads the file. Returned future throws on error.
     virtual dispatch::future<void> Upload(CatalogPtr file) = 0;
+    virtual bool Auth(wxWindow* parent) = 0;
 
 
     /// Convenicence for creating a destination from a lambda.
@@ -136,6 +137,10 @@ public:
     /// Show the window while performing background sync action. Show error if 
     static void RunSync(wxWindow *parent, std::shared_ptr<CloudSyncDestination> dest, CatalogPtr file)
     {
+        if(!dest->Auth(parent)) {
+            return;
+        }
+
         wxWindowPtr<CloudSyncProgressWindow> progress(new CloudSyncProgressWindow(parent, dest));
 #ifdef __WXOSX__
         progress->ShowWindowModal();

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -32,6 +32,10 @@
 
 #include <functional>
 #include <mutex>
+#include <stack>
+#include <iostream>
+#include <ctime>
+
 #include <boost/algorithm/string.hpp>
 #include <jwt-cpp/jwt.h>
 
@@ -360,7 +364,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
 
         for(const auto& i : r["data"]) {
             const json& d = i["data"];
-            branches[d["id"]] = d["name"];
+            branches[d["id"]] = d["name"].get<string>();
         }
 
         for(auto& i : prj->files) {

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -165,13 +165,13 @@ void CrowdinClient::HandleOAuthCallback(const std::string& uri)
         return;
     }
 
-    m_oauth->post("oauth/token", json_data(json({
+    m_oauth->post("oauth/token", json_data({
         { "grant_type", "authorization_code" },
         { "client_id", OAUTH_CLIENT_ID },
         { "client_secret", OAUTH_CLIENT_SECRET },
         { "redirect_uri", OAUTH_URI_PREFIX },
         { "code", m.str(1) }
-    }))).then([this](json r) {
+    })).then([this](json r) {
         lock_guard<mutex> lck(m_authMutex);
         if (!m_authCallback)
            return;
@@ -187,12 +187,12 @@ dispatch::future<void> CrowdinClient::RefreshToken()
         return dispatch::make_ready_future();
     }
 
-    return m_oauth->post("oauth/token", json_data(json({
+    return m_oauth->post("oauth/token", json_data({
         { "grant_type", "refresh_token" },
         { "client_id", OAUTH_CLIENT_ID },
         { "client_secret", OAUTH_CLIENT_SECRET },
         { "refresh_token", m_authRefreshToken }
-    }))).then([this](json r) {
+    })).then([this](json r) {
         lock_guard<mutex> lck(m_authMutex);
         SaveAndSetAuth(r);
     });
@@ -384,7 +384,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
     return RefreshToken().then([=] () {
     return m_api->post(
         "projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
-        json_data(json({
+        json_data({
             { "targetLanguageId", lang_tag },
             // for XLIFF files should be exported "as is" so set to `false`
             { "exportAsXliff", !wxString(file_name).Lower().EndsWith(".xliff.xliff") }
@@ -421,12 +421,12 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
             const auto storageId = r["data"]["id"].get<int>();
             return m_api->post(
                 "projects/" + std::to_string(project_id) + "/translations/" + lang_tag,
-                json_data(json({
+                json_data({
                     { "storageId", storageId },
                     { "fileId", file_id },
                     { "importDuplicates", true },
                     { "autoApproveImported", true }
-                })))
+                }))
                 .then([](json r) {
                     cout << "File uploaded: " << r << "\n\n";
                 });

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -187,9 +187,8 @@ void CrowdinClient::HandleOAuthCallback(const std::string& uri)
 
 dispatch::future<void> CrowdinClient::RefreshToken()
 {
-    if(std::time(NULL) < m_authExpireTime) {
+    if(std::time(NULL) < m_authExpireTime)
         return dispatch::make_ready_future();
-    }
 
     return m_oauth->post("oauth/token", json_data({
         { "grant_type", "refresh_token" },
@@ -222,23 +221,20 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             UserInfo u;
             u.login = str::to_wstring(d["username"]);
             u.name = str::to_wstring(d.value("fullName", ""));
-            if(u.name.empty()) {
+            if(u.name.empty())
+            {
                 // Take care that both first and last name can be empty
                 auto name = d["firstName"];
-                if(name.is_string()) {
+                if(name.is_string())
                     u.name += str::to_wstring(name);
-                }
-                if(!u.name.empty()) {
+                if(!u.name.empty())
                     u.name += ' ';
-                }
                 name = d["lastName"];
-                if(name.is_string()) {
+                if(name.is_string())
                     u.name += str::to_wstring(name);
-                }
             }
-            if(u.name.empty()) {
+            if(u.name.empty())
                 u.name = u.login;
-            }
             return u;
         });
     });
@@ -294,17 +290,18 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         const json& d = r["data"];
         prj->name = str::to_wstring(d["name"]);
         prj->id = d["id"];
-        for (const auto& langCode : d["targetLanguageIds"]) {
+        for (const auto& langCode : d["targetLanguageIds"])
             prj->languages.push_back(Language::TryParse(str::to_wstring(langCode)));
-        }
         //TODO: get more until all files gotten (if more than 500)
         return m_api->get(url + "/files?limit=500");
     }).then([this, url, prj](json r)
     {   
         // Handle project files
-        for(auto& i : r["data"]) {
+        for(auto& i : r["data"])
+        {
             const json& d = i["data"];
-            if(d["type"] != "assets") {
+            if(d["type"] != "assets")
+            {
                 const json& dir = d["directoryId"],
                             branch = d["branchId"];
                 prj->files.push_back({
@@ -325,7 +322,8 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         };
         std::map<int, dir> dirs;
 
-        for(const auto& i : r["data"]) {
+        for(const auto& i : r["data"])
+        {
             const json& d = i["data"],
                   parent = d["directoryId"];
             dirs.insert({
@@ -338,22 +336,24 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         }
 
         std::stack<std::string> path;
-        for(auto& i : prj->files) {
+        for(auto& i : prj->files)
+        {
             int dirId = i.dirId;
-            while(dirId != NO_ID) {
+            while(dirId != NO_ID)
+            {
                 const auto& dir = dirs[dirId];
                 path.push(dir.name);
                 dirId = dir.parentId;
             }
             std::string pathStr;
-            while(path.size()) {
+            while(path.size())
+            {
                 pathStr += '/';
                 pathStr += path.top();
                 path.pop();
             }
-            if(!pathStr.empty()) {
+            if(!pathStr.empty())
                 i.pathName = str::to_wstring(pathStr) + i.pathName;
-            }
         }
 
         //TODO: get more until all branches gotten (if more than 500)    
@@ -362,16 +362,15 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         // Handle branches
         std::map<int, std::string> branches;
 
-        for(const auto& i : r["data"]) {
+        for(const auto& i : r["data"])
+        {
             const json& d = i["data"];
             branches[d["id"]] = d["name"].get<std::string>();
         }
 
-        for(auto& i : prj->files) {
-            if(i.branchId != NO_ID) {
+        for(auto& i : prj->files)
+            if(i.branchId != NO_ID)
                 i.pathName = "/" + str::to_wstring(branches[i.branchId]) + i.pathName;
-            }
-        }
 
         return *prj;
     });
@@ -453,21 +452,18 @@ void CrowdinClient::SetAuth(const json& auth)
 {
      wxLogTrace("poedit.crowdin", "Authorization: %s", auth.dump().c_str());
 
-    if(auth.empty()) {
+    if(auth.empty())
         return;
-    }
 
     std::string access_token = auth["access_token"];
     m_authRefreshToken = auth["refresh_token"].get<std::string>();
     m_authExpireTime = auth["expiration_time"].get<std::time_t>();
     
     auto domain = jwt::decode(access_token).get_payload_claim("domain");
-    if(domain.get_type() == jwt::claim::type::null) {
+    if(domain.get_type() == jwt::claim::type::null)
         m_api = std::make_unique<crowdin_http_client>(*this, "https://crowdin.com/api/v2");
-    } else {
+    else
         m_api = std::make_unique<crowdin_http_client>(*this, "https://" + domain.as_string() + ".crowdin.com/api/v2");
-    }
-
     m_api->set_authorization("Bearer " + access_token);
 }
 

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -254,15 +254,21 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
             for (auto&& d : r["data"])
             {
                 const json& i = d["data"];
-                all.push_back({
-                    str::to_wstring(i["name"]),
-                    i["id"].get<int>(),
-                    //TODO: should be tested with project not owning by
-                    //      currently authorized user as well (not only
-                    //      for owning) after it will be implemented in
-                    //      in API v2 (unimplemented yet)
-                    /*(bool)i["publicDownloads"].get<int>()*/true
+                auto itPublicDownloads = i.find("publicDownloads");
+                if(itPublicDownloads != i.end()
+                    // for some wierd reason `publicDownloads` can be in 3 states:
+                    // `null`, `true` and `false` and, as investigated experimentally,
+                    // only `null` means 'Forbidden' to work with project files (to get list etc)
+                    // so hide such projects. While `false` or `true` allows to work with 
+                    // such projects normally
+                    && !itPublicDownloads->is_null()) {
+
+                    all.push_back({
+                        str::to_wstring(i["name"]),
+                        i["id"].get<int>()
                 });
+
+                }
             }
             return all;
         });
@@ -368,6 +374,8 @@ json CrowdinClient::LoadAuth()
 
 void CrowdinClient::SetAuth(const json& auth)
 {
+    cout << endl << endl << "Authorization: " << auth << endl << endl;
+
     if(auth.empty()) {
         return;
     }

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -189,7 +189,18 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             u.login = str::to_wstring(d["username"]);
             u.name = str::to_wstring(d.value("fullName", ""));
             if(u.name.empty()) {
-                u.name = str::to_wstring(d["firstName"]) + " " + str::to_wstring(d["lastName"]);
+                // Take care that both first and last name can be empty
+                auto name = d["firstName"];
+                if(name.is_string()) {
+                    u.name += str::to_wstring(name);
+                }
+                if(!u.name.empty()) {
+                    u.name += ' ';
+                }
+                name = d["lastName"];
+                if(name.is_string()) {
+                    u.name += str::to_wstring(name);
+                }
             }
             if(u.name.empty()) {
                 u.name = u.login;

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -257,7 +257,9 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                     //TODO: files should be with full path
                     for(auto&& i : r["data"]) {
                         const json& d = i["data"];
-                        prj.files.push_back({L"/" + str::to_wstring(d["name"]), d["id"]});
+                        if(d["type"] != "assets") {
+                            prj.files.push_back({L"/" + str::to_wstring(d["name"]), d["id"]});
+                        }
                     }
                     //TODO: get more until all files gotten (if more than 500)
                     return prj;

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -418,7 +418,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
     return m_api->post(
             "storages",
             octet_stream_data(file_content),
-            { { "Crowdin-API-FileName", L"poedit.xliff"} }
+            { { "Crowdin-API-FileName", "poedit.xliff"} }
         )
         .then([this, project_id, file_id, lang_tag] (json r) {
             cout << "File uploaded to temporary storage: " << r << "\n\n";

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -164,7 +164,7 @@ void CrowdinClient::HandleOAuthCallback(const std::string& uri)
         return;
     }
 
-    m_oauth->post("/oauth/token", json_data(json({
+    m_oauth->post("oauth/token", json_data(json({
         { "grant_type", "authorization_code" },
         { "client_id", OAUTH_CLIENT_ID },
         { "client_secret", OAUTH_CLIENT_SECRET },
@@ -192,7 +192,7 @@ bool CrowdinClient::IsOAuthCallback(const std::string& uri)
 
 dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
 {
-    return m_api->get("/user")
+    return m_api->get("user")
         .then([](json r)
         {
             cout << "\n\nGot user info: " << r << "\n\n";
@@ -226,7 +226,7 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 {
     // TODO: handle pagination if projects more than 500
     //       (what is quite rare case I guess)
-    return m_api->get("/projects?limit=500")
+    return m_api->get("projects?limit=500")
         .then([](json r)
         {
             cout << "\n\nGot projects: " << r << endl<<endl;
@@ -251,7 +251,7 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 
 dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const int project_id)
 {
-    auto url = "/projects/" + std::to_string(project_id);
+    auto url = "projects/" + std::to_string(project_id);
     return m_api->get(url)
         .then([this, url](json r)
         {
@@ -288,7 +288,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
 {
     cout << "\n\nGetting file URL: " << "/projects/" + std::to_string(project_id) + "/files/" + std::to_string(file_id) + "/download" << "\n\n";
     return m_api->post(
-        "/projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
+        "projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
         json_data(json({
             { "targetLanguageId", lang_tag },
             // for XLIFF files should be exported "as is" so set to `false`
@@ -307,7 +307,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                                                  const std::string& file_content)
 {
     return m_api->post(
-            "/storages",
+            "storages",
             octet_stream_data(file_content),
             { { "Crowdin-API-FileName", L"poedit.xliff"} }
         )
@@ -315,7 +315,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
             cout << "File uploaded to temporary storage: " << r << "\n\n";
             const auto storageId = r["data"]["id"].get<int>();
             return m_api->post(
-                "/projects/" + std::to_string(project_id) + "/translations/" + lang_tag,
+                "projects/" + std::to_string(project_id) + "/translations/" + lang_tag,
                 json_data(json({
                     { "storageId", storageId },
                     { "fileId", file_id },

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -282,7 +282,11 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                                                  const std::string& lang_tag,
                                                  const std::string& file_content)
 {
-    return m_api->post("/storages", octet_stream_data(file_content))
+    return m_api->post(
+            "/storages",
+            octet_stream_data(file_content),
+            { { "Crowdin-API-FileName", L"poedit.xliff"} }
+        )
         .then([this, project_id, file_id, lang_tag] (json r) {
             cout << "File uploaded to temporary storage: " << r << "\n\n";
             const auto storageId = r["data"]["id"].get<int>();
@@ -290,10 +294,12 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                 "/projects/" + std::to_string(project_id) + "/translations/" + lang_tag,
                 json_data(json({
                     { "storageId", storageId },
-                    { "fileId", file_id }
+                    { "fileId", file_id },
+                    { "importDuplicates", true },
+                    { "autoApproveImported", true }
                 })))
                 .then([](json r) {
-                    cout << "File uploaded" << r << "\n\n";
+                    cout << "File uploaded: " << r << "\n\n";
                 });
         });
 }

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -125,7 +125,7 @@ protected:
 CrowdinClient::CrowdinClient() :
     m_api(new crowdin_http_client(*this, "https://serhiy.crowdin.com/api/v2")),
     m_oauth(new crowdin_http_client(*this, "https://accounts.crowdin.com")),
-    m_downloader(new crowdin_http_client(*this, "https://production-enterprise-tmp.downloads.crowdin.com"/*"https://crowdin-importer.downloads.crowdin.com"*/)) 
+    m_downloader(new crowdin_http_client(*this, "https://production-enterprise-tmp.downloads.crowdin.com"/*"https://crowdin-importer.downloads.crowdin.com"*/))
 {
     SignInIfAuthorized();
 }
@@ -154,7 +154,7 @@ void CrowdinClient::HandleOAuthCallback(const std::string& uri)
         || m.str(2) != OAUTH_STATE) {
         return;
     }
-    
+
     m_oauth->post("/oauth/token", json_data(json({
         { "grant_type", "authorization_code" },
         { "client_id", OAUTH_CLIENT_ID },
@@ -288,7 +288,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const std::string& project_id,
     data.add_value("import_duplicates", "0");
     data.add_value("import_eq_suggestions", "0");
     data.add_file("files[" + str::to_utf8(file) + "]", "upload.po", file_content);
-    
+
     return m_api->post(url, data).then([](json){});
 }
 

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -101,12 +101,24 @@ protected:
     std::string parse_json_error(const json& response) const override
     {
         cout << "\n\nJSON error: " << response << "\n\n";
-        std::string msg = response["error"]["message"];
 
-        // Translate commonly encountered messages:
-        if (msg == "Translations download is forbidden by project owner")
-            msg = _("Downloading translations is disabled in this project.").utf8_str();
-        return msg;
+        try
+        {
+            return response.at("errors").at(0).at("error").at("errors").at(0).at("message");
+        }
+        catch(...)
+        {
+            try
+            {
+                return response.at("error").at("message");
+            }
+            catch (...)
+            {
+                std::string msg;
+                msg = _("JSON request error").utf8_str();
+                return msg;
+            }
+        }
     }
 
     void on_error_response(int& statusCode, std::string& message) override

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -256,18 +256,20 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
 }
 
 
-dispatch::future<void> CrowdinClient::DownloadFile(const int project_id,
-                                                   const int file_id,
-                                                   const std::wstring& lang_tag,
+dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
+                                                   const long file_id,
+                                                   const std::wstring& file_name,
+                                                   const std::string& lang_tag,
                                                    const std::wstring& output_file)
 {
     cout << "\n\nGetting file URL: " << "/projects/" + std::to_string(project_id) + "/files/" + std::to_string(file_id) + "/download" << "\n\n";
     return m_api->post(
         "/projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
         json_data(json({
-            { "targetLanguageId", str::to_utf8(lang_tag) },
-            { "exportAsXliff", true }
-        })))
+            { "targetLanguageId", lang_tag },
+            // for XLIFF files should be exported "as is" so set to `false`
+            { "exportAsXliff", !wxString(file_name).Lower().EndsWith(".xliff.xliff") }
+        }))
         .then([this, output_file] (json r) {
             cout << "\n\nGotten file URL: "<< r << "\n\n";
             return m_downloader->download(r["data"]["url"], output_file);
@@ -275,21 +277,25 @@ dispatch::future<void> CrowdinClient::DownloadFile(const int project_id,
 }
 
 
-dispatch::future<void> CrowdinClient::UploadFile(const std::string& project_id,
-                                                 const std::wstring& file,
-                                                 const Language& lang,
+dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
+                                                 const long file_id,
+                                                 const std::string& lang_tag,
                                                  const std::string& file_content)
 {
-    auto url = "/api/project/" + project_id + "/upload-translation";
-
-    multipart_form_data data;
-    data.add_value("json", "");
-    data.add_value("language", lang.LanguageTag());
-    data.add_value("import_duplicates", "0");
-    data.add_value("import_eq_suggestions", "0");
-    data.add_file("files[" + str::to_utf8(file) + "]", "upload.po", file_content);
-
-    return m_api->post(url, data).then([](json){});
+    return m_api->post("/storages", octet_stream_data(file_content))
+        .then([this, project_id, file_id, lang_tag] (json r) {
+            cout << "File uploaded to temporary storage: " << r << "\n\n";
+            const auto storageId = r["data"]["id"].get<int>();
+            return m_api->post(
+                "/projects/" + std::to_string(project_id) + "/translations/" + lang_tag,
+                json_data(json({
+                    { "storageId", storageId },
+                    { "fileId", file_id }
+                })))
+                .then([](json r) {
+                    cout << "File uploaded" << r << "\n\n";
+                });
+        });
 }
 
 

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -412,7 +412,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
 
 dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                                                  const long file_id,
-                                                 const std::string& lang_tag,
+                                                 const Language& lang,
                                                  const std::string& file_content)
 {
     return RefreshToken().then([=] () {
@@ -421,11 +421,11 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
             octet_stream_data(file_content),
             { { "Crowdin-API-FileName", "poedit.xliff"} }
         )
-        .then([this, project_id, file_id, lang_tag] (json r) {
+        .then([this, project_id, file_id, lang] (json r) {
             wxLogTrace("poedit.crowdin", "File uploaded to temporary storage: %s", r.dump().c_str());
             const auto storageId = r["data"]["id"].get<int>();
             return m_api->post(
-                "projects/" + std::to_string(project_id) + "/translations/" + lang_tag,
+                "projects/" + std::to_string(project_id) + "/translations/" + lang.LanguageTag(),
                 json_data({
                     { "storageId", storageId },
                     { "fileId", file_id },

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -80,29 +80,37 @@ public:
     struct ProjectListing
     {
         std::wstring name;
-        std::string identifier;
+        int id;
         bool downloadable;
     };
 
     /// Retrieve listing of projects accessible to the user
     dispatch::future<std::vector<ProjectListing>> GetUserProjects();
 
+    // File information
+    struct FileInfo
+    {
+        std::wstring pathName;
+        int id;
+        
+    };
+
+
     /// Project detailed information
     struct ProjectInfo
     {
         std::wstring name;
-        std::string identifier;
+        int id;
         std::vector<Language> languages;
-        std::vector<std::wstring> files;
+        std::vector<FileInfo> files;
     };
 
     /// Retrieve listing of projects accessible to the user
-    dispatch::future<ProjectInfo> GetProjectInfo(const std::string& project_id);
+    dispatch::future<ProjectInfo> GetProjectInfo(const int project_id);
 
     /// Asynchronously download specific Crowdin file into @a output_file.
-    dispatch::future<void> DownloadFile(const std::string& project_id,
-                                        const std::wstring& file,
-                                        const Language& lang,
+    dispatch::future<void> DownloadFile(const int project_id,
+                                        const int file_id,
                                         const std::wstring& output_file);
 
     /// Asynchronously upload specific Crowdin file data.
@@ -120,10 +128,7 @@ private:
     void SaveAndSetToken(const std::string& token);
 
     class crowdin_http_client;
-    class crowdin_oauth_client;
-    std::unique_ptr<crowdin_http_client> m_api;
-    std::unique_ptr<crowdin_oauth_client> m_oauth;
-
+    std::unique_ptr<crowdin_http_client> m_api, m_oauth, m_downloader;
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
 
     static CrowdinClient *ms_instance;

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -92,7 +92,7 @@ public:
     struct FileInfo
     {
         std::wstring pathName;
-        int id;
+        int id, dirId, branchId;
         
     };
 

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -120,7 +120,9 @@ private:
     void SaveAndSetToken(const std::string& token);
 
     class crowdin_http_client;
+    class crowdin_oauth_client;
     std::unique_ptr<crowdin_http_client> m_api;
+    std::unique_ptr<crowdin_oauth_client> m_oauth;
 
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
 

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -83,7 +83,6 @@ public:
     {
         std::wstring name;
         int id;
-        bool downloadable;
     };
 
     /// Retrieve listing of projects accessible to the user

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -119,7 +119,7 @@ public:
     /// Asynchronously upload specific Crowdin file data.
     dispatch::future<void> UploadFile(const long project_id,
                                       const long file_id,
-                                      const std::string& lang_tag,
+                                      const Language& lang,
                                       const std::string& file_content);
 
 private:

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -132,6 +132,7 @@ private:
     class crowdin_http_client;
     std::unique_ptr<crowdin_http_client> m_api, m_oauth, m_downloader;
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
+    std::mutex m_authCallbackMutex;
 
     static CrowdinClient *ms_instance;
 };

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -133,7 +133,7 @@ private:
     dispatch::future<void> RefreshToken();
 
     class crowdin_http_client;
-    std::unique_ptr<crowdin_http_client> m_api, m_oauth, m_downloader;
+    std::unique_ptr<crowdin_http_client> m_api, m_oauth;
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
     std::mutex m_authMutex;
     std::string m_authRefreshToken;

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -109,15 +109,16 @@ public:
     dispatch::future<ProjectInfo> GetProjectInfo(const int project_id);
 
     /// Asynchronously download specific Crowdin file into @a output_file.
-    dispatch::future<void> DownloadFile(const int project_id,
-                                        const int file_id,
-                                        const std::wstring& lang_tag,
+    dispatch::future<void> DownloadFile(const long project_id,
+                                        const long file_id,
+                                        const std::wstring& file_name,
+                                        const std::string& lang_tag,
                                         const std::wstring& output_file);
 
     /// Asynchronously upload specific Crowdin file data.
-    dispatch::future<void> UploadFile(const std::string& project_id,
-                                      const std::wstring& file,
-                                      const Language& lang,
+    dispatch::future<void> UploadFile(const long project_id,
+                                      const long file_id,
+                                      const std::string& lang_tag,
                                       const std::string& file_content);
 
 private:

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -111,6 +111,7 @@ public:
     /// Asynchronously download specific Crowdin file into @a output_file.
     dispatch::future<void> DownloadFile(const int project_id,
                                         const int file_id,
+                                        const std::wstring& lang_tag,
                                         const std::wstring& output_file);
 
     /// Asynchronously upload specific Crowdin file data.

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -471,7 +471,7 @@ private:
 
         auto outfile = std::make_shared<TempOutputFileFor>(OutLocalFilename);
         CrowdinClient::Get().DownloadFile(
-                crowdin_prj, crowdin_file.id,
+                crowdin_prj, crowdin_file.id, str::to_wstring(crowdin_lang.LanguageTag()),
                 outfile->FileName().ToStdWstring()
             )
             .then_on_window(this, [=]{
@@ -500,9 +500,9 @@ private:
         if (!wxFileName::DirExists(cache))
             wxFileName::Mkdir(cache, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 
-        auto basename = name.AfterLast('/').BeforeLast('.');
+        auto basename = name.AfterLast('/');
 
-        return wxString::Format("%s%c%s_%s_%s.po", cache, wxFILE_SEP_PATH, m_info.name, basename, lang.Code());
+        return wxString::Format("%s%c%s_%s_%s.xliff", cache, wxFILE_SEP_PATH, m_info.name, lang.Code(), basename);
     }
 
 private:

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -585,7 +585,6 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
                 dispatch::on_main([=]{
                     dlg->Activity->Start(_(L"Downloading latest translations…"));
                 });
-
                 return CrowdinClient::Get().DownloadFile(
                         xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), xliff->GetFileName().ToStdWstring(), xliff->GetLanguage().LanguageTag(),
                         outfile.ToStdWstring()

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -548,7 +548,7 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
         return;
     }
 
-    std::cout << "Crowdin syncing file ..." << std::endl;
+    wxLogTrace("poedit.crowdin", "Crowdin syncing file ...");
 
     wxWindowPtr<CloudSyncProgressWindow> dlg(new CloudSyncProgressWindow(parent));
 
@@ -616,7 +616,7 @@ dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
 {
     const XLIFF1Catalog* xliff = dynamic_cast<const XLIFF1Catalog*>(file.get());
   
-    std::cout << "Uploading file: " << xliff->GetFileName() << std::endl;
+    wxLogTrace("Uploading file: %s", xliff->GetFileName().c_str());
     return CrowdinClient::Get().UploadFile(
                 xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), file->GetLanguage().LanguageTag(),
                 file->SaveToBuffer()

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -37,6 +37,7 @@
 #include "languagectrl.h"
 #include "str_helpers.h"
 #include "utility.h"
+#include "catalog_xliff.h"
 
 #include <wx/app.h>
 #include <wx/artprov.h>
@@ -464,13 +465,13 @@ private:
         auto crowdin_file = m_info.files[m_file->GetSelection() - 1];
         auto crowdin_lang = m_info.languages[m_language->GetSelection() - 1];
         LanguageDialog::SetLastChosen(crowdin_lang);
-        OutLocalFilename = CreateLocalFilename(crowdin_file.pathName, crowdin_lang, m_info.id, m_info.name);
+        OutLocalFilename = CreateLocalFilename(crowdin_file.id, crowdin_file.pathName, crowdin_lang, m_info.id, m_info.name);
 
         m_activity->Start(_(L"Downloading latest translations…"));
 
         auto outfile = std::make_shared<TempOutputFileFor>(OutLocalFilename);
         CrowdinClient::Get().DownloadFile(
-                m_info.id, crowdin_file.id, str::to_wstring(crowdin_lang.LanguageTag()),
+                m_info.id, crowdin_file.id, OutLocalFilename.ToStdWstring(), crowdin_lang.LanguageTag(),
                 outfile->FileName().ToStdWstring()
             )
             .then_on_window(this, [=]{
@@ -480,29 +481,17 @@ private:
             .catch_all(m_activity->HandleError);
     }
 
-    wxString CreateLocalFilename(const wxString& name, const Language& lang, const int projectId, const wxString& projectName)
+    wxString CreateLocalFilename(const long fileId, const wxString& name, const Language& lang, const long projectId, const wxString& projectName)
     {
-        wxString cache;
-    #if defined(__WXOSX__)
-        cache = wxGetHomeDir() + "/Library/Caches/net.poedit.Poedit";
-    #elif defined(__UNIX__)
-        if (!wxGetEnv("XDG_CACHE_HOME", &cache))
-            cache = wxGetHomeDir() + "/.cache";
-        cache += "/poedit";
-    #else
-        cache = wxStandardPaths::Get().GetUserDataDir() + wxFILE_SEP_PATH + "Cache";
-    #endif
-
-        cache += wxFILE_SEP_PATH;
-        cache += "Crowdin";
-
         auto localName = name;
         localName.Replace("/", wxFILE_SEP_PATH);
 
         wxString localFileName;
-        localFileName << cache << wxFILE_SEP_PATH << projectId << ' ' << projectName
+        localFileName << CloudSyncDestination::GetCacheDir() << wxFILE_SEP_PATH << "Crowdin"
+                    << wxFILE_SEP_PATH << projectName
                     << wxFILE_SEP_PATH << lang.Code()
-                    << wxFILE_SEP_PATH << localName + ".xliff";
+                    << wxFILE_SEP_PATH << localName.BeforeLast(wxFILE_SEP_PATH) << wxFILE_SEP_PATH
+                    << projectId << '_' << fileId << '_' << localName.AfterLast(wxFILE_SEP_PATH) << ".xliff";
         auto localDirName = localFileName.BeforeLast(wxFILE_SEP_PATH);
  
         if (!wxFileName::DirExists(localDirName))
@@ -561,13 +550,6 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
 
     std::cout << "Crowdin syncing file ..." << std::endl;
 
-    const auto& header = catalog->Header();
-    auto crowdin_prj = header.GetHeader("X-Crowdin-Project");
-    auto crowdin_file = header.GetHeader("X-Crowdin-File");
-    auto crowdin_lang = header.HasHeader("X-Crowdin-Language")
-                        ? Language::TryParse(header.GetHeader("X-Crowdin-Language").ToStdWstring())
-                        : catalog->GetLanguage();
-
     wxWindowPtr<CloudSyncProgressWindow> dlg(new CloudSyncProgressWindow(parent));
 
     auto handle_error = [=](dispatch::exception_ptr e){
@@ -589,21 +571,23 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
 
     // TODO: nicer API for this.
     // This must be done right after entering the modal loop (on non-OSX)
-    /*dlg->CallAfter([=]{
+    dlg->CallAfter([=]{
+        const XLIFF1Catalog* xliff = dynamic_cast<const XLIFF1Catalog*>(catalog.get());
+        
         CrowdinClient::Get().UploadFile(
-                str::to_utf8(crowdin_prj), str::to_wstring(crowdin_file), crowdin_lang,
+                xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), catalog->GetLanguage().LanguageTag(),
                 catalog->SaveToBuffer()
             )
             .then([=]{
                 auto tmpdir = std::make_shared<TempDirectory>();
-                auto outfile = tmpdir->CreateFileName("crowdin.po");
+                auto outfile = tmpdir->CreateFileName("crowdin.xliff");
 
                 dispatch::on_main([=]{
                     dlg->Activity->Start(_(L"Downloading latest translations…"));
                 });
 
                 return CrowdinClient::Get().DownloadFile(
-                        str::to_utf8(crowdin_prj), str::to_wstring(crowdin_file), crowdin_lang,
+                        xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), xliff->GetFileName().ToStdWstring(), xliff->GetLanguage().LanguageTag(),
                         outfile.ToStdWstring()
                     )
                     .then_on_main([=]
@@ -619,7 +603,7 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
                     .catch_all(handle_error);
             })
             .catch_all(handle_error);
-    });ttt*/
+    });
 
     dlg->ShowWindowModal();
 }
@@ -627,16 +611,11 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
 
 dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
 {
-    const auto& header = file->Header();
-    auto crowdin_prj = header.GetHeader("X-Crowdin-Project");
-    auto crowdin_file = header.GetHeader("X-Crowdin-File");
-    auto crowdin_lang = header.HasHeader("X-Crowdin-Language")
-                        ? Language::TryParse(header.GetHeader("X-Crowdin-Language").ToStdWstring())
-                        : file->GetLanguage();
-
-    std::cout << "Uploading file: " << crowdin_file << std::endl;
+    const XLIFF1Catalog* xliff = dynamic_cast<const XLIFF1Catalog*>(file.get());
+  
+    std::cout << "Uploading file: " << xliff->GetFileName() << std::endl;
     return CrowdinClient::Get().UploadFile(
-                str::to_utf8(crowdin_prj), str::to_wstring(crowdin_file), crowdin_lang,
+                xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), file->GetLanguage().LanguageTag(),
                 file->SaveToBuffer()
             );
 }

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -575,7 +575,7 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
         const XLIFF1Catalog* xliff = dynamic_cast<const XLIFF1Catalog*>(catalog.get());
         
         CrowdinClient::Get().UploadFile(
-                xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), catalog->GetLanguage().LanguageTag(),
+                xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), catalog->GetLanguage(),
                 catalog->SaveToBuffer()
             )
             .then([=]{
@@ -618,7 +618,7 @@ dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
   
     wxLogTrace("Uploading file: %s", xliff->GetFileName().c_str());
     return CrowdinClient::Get().UploadFile(
-                xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), file->GetLanguage().LanguageTag(),
+                xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), file->GetLanguage(),
                 file->SaveToBuffer()
             );
 }

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -607,6 +607,10 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
     dlg->ShowWindowModal();
 }
 
+bool CrowdinSyncDestination::Auth(wxWindow* parent) {
+    return CrowdinClient::Get().IsSignedIn()
+            || CrowdinLoginDialog(parent).ShowModal() == wxID_OK;
+}
 
 dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
 {

--- a/src/crowdin_gui.h
+++ b/src/crowdin_gui.h
@@ -83,7 +83,7 @@ class CrowdinSyncDestination : public CloudSyncDestination
 {
 public:
     wxString GetName() const override { return "Crowdin"; }
-
+    bool Auth(wxWindow* parent) override;
     dispatch::future<void> Upload(CatalogPtr file) override;
 };
 

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1097,8 +1097,6 @@ void PoeditFrame::OnOpenFromCrowdin(wxCommandEvent&)
     DoIfCanDiscardCurrentDoc([=]{
         CrowdinOpenFile(this, [=](wxString name){
             DoOpenFile(name);
-            //if (m_catalog)
-            //    m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
         });
     });
 }
@@ -2716,12 +2714,20 @@ void PoeditFrame::WriteCatalog(const wxString& catalog, TFunctor completionHandl
     if (ManagerFrame::Get())
         ManagerFrame::Get()->NotifyFileChanged(GetFileName());
 
-    if (!m_syncing // avoid redundant upload during same call of OnUpdateFromCrowdin()=>
-                   // 1. =>DoIfCanDiscardCurrentDoc()=>Upload()
-                   // 2. =>CrowdinSyncFile()=>UploadFile()
-        && m_catalog->GetCloudSync())
-    {
-        CloudSyncProgressWindow::RunSync(this, m_catalog->GetCloudSync(), m_catalog);
+    if(!m_catalog->GetCloudSync()) {
+        if(m_catalog->IsFromCrowdin()) {
+            m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
+        }
+    }
+    
+    if (m_catalog->GetCloudSync()) {
+        // Avoid redundant upload during same call of 
+        // OnUpdateFromCrowdin()=>
+        // 1. =>DoIfCanDiscardCurrentDoc()=>Upload()
+        // 2. =>CrowdinSyncFile()=>UploadFile()
+        if(!m_syncing) {
+            CloudSyncProgressWindow::RunSync(this, m_catalog->GetCloudSync(), m_catalog);
+        }
     }
 
     if (tmUpdateThread.valid())

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -2714,21 +2714,17 @@ void PoeditFrame::WriteCatalog(const wxString& catalog, TFunctor completionHandl
     if (ManagerFrame::Get())
         ManagerFrame::Get()->NotifyFileChanged(GetFileName());
 
-    if(!m_catalog->GetCloudSync()) {
-        if(m_catalog->IsFromCrowdin()) {
+    if(!m_catalog->GetCloudSync())
+        if(m_catalog->IsFromCrowdin())
             m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
-        }
-    }
     
-    if (m_catalog->GetCloudSync()) {
+    if (m_catalog->GetCloudSync())
         // Avoid redundant upload during same call of 
         // OnUpdateFromCrowdin()=>
         // 1. =>DoIfCanDiscardCurrentDoc()=>Upload()
         // 2. =>CrowdinSyncFile()=>UploadFile()
-        if(!m_syncing) {
+        if(!m_syncing)
             CloudSyncProgressWindow::RunSync(this, m_catalog->GetCloudSync(), m_catalog);
-        }
-    }
 
     if (tmUpdateThread.valid())
         tmUpdateThread.wait();
@@ -2815,7 +2811,8 @@ void PoeditFrame::OnPurgeDeleted(wxCommandEvent& WXUNUSED(event))
     dlg->SetYesNoLabels(_("Purge"), _("Keep"));
 
     dlg->ShowWindowModalThenDo([this,dlg](int retcode){
-        if (retcode == wxID_YES) {
+        if (retcode == wxID_YES)
+        {
             m_catalog->RemoveDeletedItems();
             m_modified = true;
             UpdateTitle();

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1764,6 +1764,7 @@ void PoeditFrame::OnUpdateFromPOTUpdate(wxUpdateUIEvent& event)
 #ifdef HAVE_HTTP_CLIENT
 void PoeditFrame::OnUpdateFromCrowdin(wxCommandEvent&)
 {
+    m_syncing = true;
     DoIfCanDiscardCurrentDoc([=]{
         CrowdinSyncFile(this, m_catalog, [=](std::shared_ptr<Catalog> cat){
             m_catalog = cat;
@@ -1772,6 +1773,7 @@ void PoeditFrame::OnUpdateFromCrowdin(wxCommandEvent&)
             RefreshControls();
         });
     });
+    m_syncing = false;
 }
 
 void PoeditFrame::OnUpdateFromCrowdinUpdate(wxUpdateUIEvent& event)
@@ -2715,7 +2717,10 @@ void PoeditFrame::WriteCatalog(const wxString& catalog, TFunctor completionHandl
     if (ManagerFrame::Get())
         ManagerFrame::Get()->NotifyFileChanged(GetFileName());
 
-    if (m_catalog->GetCloudSync())
+    if (!m_syncing // avoid redundant upload during same call of OnUpdateFromCrowdin()=>
+                   // 1. =>DoIfCanDiscardCurrentDoc()=>Upload()
+                   // 2. =>CrowdinSyncFile()=>UploadFile()
+        && m_catalog->GetCloudSync())
     {
         CloudSyncProgressWindow::RunSync(this, m_catalog->GetCloudSync(), m_catalog);
     }

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1098,8 +1098,8 @@ void PoeditFrame::OnOpenFromCrowdin(wxCommandEvent&)
     DoIfCanDiscardCurrentDoc([=]{
         CrowdinOpenFile(this, [=](wxString name){
             DoOpenFile(name);
-            if (m_catalog)
-                m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
+            //if (m_catalog)
+            //    m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
         });
     });
 }

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -88,7 +88,6 @@
 #include "spellchecking.h"
 #include "str_helpers.h"
 
-
 namespace
 {
 

--- a/src/edframe.h
+++ b/src/edframe.h
@@ -379,6 +379,7 @@ private:
         bool m_hasObsoleteItems;
         bool m_displayIDs;
         bool m_setSashPositionsWhenMaximized;
+        bool m_syncing = false;
 };
 
 

--- a/src/gexecute.cpp
+++ b/src/gexecute.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include <wx/defs.h>
 #include <wx/utils.h>
 #include <wx/log.h>
 #include <wx/process.h>

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -34,7 +34,6 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
-
 multipart_form_data::multipart_form_data()
 {
     boost::uuids::random_generator gen;

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -127,7 +127,7 @@ public:
         default_flags = 0
     };
 
-    using hdrs_t = std::vector<std::pair<std::string, std::wstring>>;
+    using headers = std::vector<std::pair<std::string, std::wstring>>;
 
     /**
         Creates an instance of the client object.
@@ -164,7 +164,7 @@ public:
     /**
         Perform a POST request with multipart/form-data formatted @a params.
      */
-    dispatch::future<json> post(const std::string& url, const http_body_data& data, const hdrs_t& hdrs = hdrs_t());
+    dispatch::future<json> post(const std::string& url, const http_body_data& data, const headers& hdrs = headers());
 
 
     // Helper for encoding text as URL-encoded UTF-8

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -127,7 +127,7 @@ public:
         default_flags = 0
     };
 
-    using headers = std::vector<std::pair<std::string, std::wstring>>;
+    using headers = std::vector<std::pair<std::string, std::string>>;
 
     /**
         Creates an instance of the client object.

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -52,6 +52,20 @@ public:
     virtual std::string body() const = 0;
 };
 
+class octet_stream_data : public http_body_data
+{
+public:
+    octet_stream_data(const std::string& body) : m_body(body) {};
+
+    /// Content-Type header to use with the data.
+    std::string content_type() const override { return "application/octet-stream"; };
+
+    /// Returns generated body of the request.
+    std::string body() const override { return m_body; };
+private:
+    std::string m_body;
+};
+
 /// Stores POSTed data (RFC 1867)
 class multipart_form_data : public http_body_data
 {

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -127,6 +127,8 @@ public:
         default_flags = 0
     };
 
+    using hdrs_t = std::vector<std::pair<std::string, std::wstring>>;
+
     /**
         Creates an instance of the client object.
         
@@ -162,7 +164,7 @@ public:
     /**
         Perform a POST request with multipart/form-data formatted @a params.
      */
-    dispatch::future<json> post(const std::string& url, const http_body_data& data);
+    dispatch::future<json> post(const std::string& url, const http_body_data& data, const hdrs_t& hdrs = hdrs_t());
 
 
     // Helper for encoding text as URL-encoded UTF-8

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -232,7 +232,14 @@ public:
     {
         http::http_request req(http::methods::POST);
         for(const auto& h : hdrs) {
-            req.headers().add(h.first, h.second);
+            req.headers().add(
+                // Take care about conversion from std::string in case of
+                // std::wstring used in headers as well what is default
+                // for _WIN32 in cpprest for some reason
+                // (it's safe since we expect only ANSI in header names)
+                utility::string_t(h.first.begin(), h.first.end()),
+                h.second
+            );
         }
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -228,7 +228,7 @@ public:
         });
     }
 
-    dispatch::future<::json> post(const std::string& url, const http_body_data& data, const http_client::hdrs_t& hdrs)
+    dispatch::future<::json> post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
     {
         http::http_request req(http::methods::POST);
         for(const auto& h : hdrs) {
@@ -364,7 +364,7 @@ dispatch::future<void> http_client::download(const std::string& url, const std::
     return m_impl->download(url, output_file);
 }
 
-dispatch::future<::json> http_client::post(const std::string& url, const http_body_data& data, const hdrs_t& hdrs)
+dispatch::future<::json> http_client::post(const std::string& url, const http_body_data& data, const headers& hdrs)
 {
     return m_impl->post(url, data, hdrs);
 }

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -238,7 +238,7 @@ public:
                 // for _WIN32 in cpprest for some reason
                 // (it's safe since we expect only ANSI in header names)
                 utility::string_t(h.first.begin(), h.first.end()),
-                h.second
+                utility::string_t(h.second.begin(), h.second.end())
             );
         }
         req.headers().add(http::header_names::user_agent, m_userAgent);

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -228,9 +228,12 @@ public:
         });
     }
 
-    dispatch::future<::json> post(const std::string& url, const http_body_data& data)
+    dispatch::future<::json> post(const std::string& url, const http_body_data& data, const http_client::hdrs_t& hdrs)
     {
         http::http_request req(http::methods::POST);
+        for(const auto& h : hdrs) {
+            req.headers().add(h.first, h.second);
+        }
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())
@@ -354,7 +357,7 @@ dispatch::future<void> http_client::download(const std::string& url, const std::
     return m_impl->download(url, output_file);
 }
 
-dispatch::future<::json> http_client::post(const std::string& url, const http_body_data& data)
+dispatch::future<::json> http_client::post(const std::string& url, const http_body_data& data, const hdrs_t& hdrs)
 {
-    return m_impl->post(url, data);
+    return m_impl->post(url, data, hdrs);
 }

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -199,7 +199,7 @@ public:
 
     dispatch::future<void> download(const std::string& url, const std::wstring& output_file)
     {
-        std::cout << "\n\nDowloading file: " << url << "\n\n";
+        wxLogTrace("poedit.http_client", "Dowloading file: %s", url.c_str());
         using namespace concurrency::streams;
         auto fileStream = std::make_shared<ostream>();
 
@@ -217,13 +217,13 @@ public:
         })
         .then([=](http::http_response response)
         {
-            std::cout << "\n\nDownloading file response: "<<response.status_code()<<", "<<response.headers().content_type()<<"\n\n";
+            wxLogTrace("poedit.http_client", "Downloading file response: %hu, %s", response.status_code(), response.headers().content_type().c_str());
             handle_error(response);
             return response.body().read_to_end(fileStream->streambuf());
         })
         .then([=](size_t)
         {
-            std::cout << "\n\nDownloading file: closing\n\n";
+            wxLogTrace("poedit.http_client", "Downloading file: closing");
             return fileStream->close();
         });
     }

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -182,11 +182,6 @@ public:
     dispatch::future<::json> get(const std::string& url)
     {
         http::http_request req(http::methods::GET);
-        //TODO: figure out why Crowdin API v2 GET method (at least `/user`)
-        //      returns below errors unless below line commented
-        //      HTTP error: 400 Bad Request
-        //      JSON error: Incorrect Accept Header. 'application/json' expected
-        //req.headers().add(http::header_names::accept,     L"application/json");
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())
@@ -236,7 +231,6 @@ public:
     dispatch::future<::json> post(const std::string& url, const http_body_data& data)
     {
         http::http_request req(http::methods::POST);
-        req.headers().add(http::header_names::accept,     L"application/json");
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -182,7 +182,11 @@ public:
     dispatch::future<::json> get(const std::string& url)
     {
         http::http_request req(http::methods::GET);
-        req.headers().add(http::header_names::accept,     L"application/json");
+        //TODO: figure out why Crowdin API v2 GET method (at least `/user`)
+        //      returns below errors unless below line commented
+        //      HTTP error: 400 Bad Request
+        //      JSON error: Incorrect Accept Header. 'application/json' expected
+        //req.headers().add(http::header_names::accept,     L"application/json");
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -231,7 +231,7 @@ public:
     dispatch::future<::json> post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
     {
         http::http_request req(http::methods::POST);
-        for(const auto& h : hdrs) {
+        for(const auto& h : hdrs)
             req.headers().add(
                 // Take care about conversion from std::string in case of
                 // std::wstring used in headers as well what is default
@@ -240,7 +240,6 @@ public:
                 utility::string_t(h.first.begin(), h.first.end()),
                 utility::string_t(h.second.begin(), h.second.end())
             );
-        }
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -204,6 +204,7 @@ public:
 
     dispatch::future<void> download(const std::string& url, const std::wstring& output_file)
     {
+        std::cout << "\n\nDowloading file: " << url << "\n\n";
         using namespace concurrency::streams;
         auto fileStream = std::make_shared<ostream>();
 
@@ -221,11 +222,13 @@ public:
         })
         .then([=](http::http_response response)
         {
+            std::cout << "\n\nDownloading file response: "<<response.status_code()<<", "<<response.headers().content_type()<<"\n\n";
             handle_error(response);
             return response.body().read_to_end(fileStream->streambuf());
         })
         .then([=](size_t)
         {
+            std::cout << "\n\nDownloading file: closing\n\n";
             return fileStream->close();
         });
     }

--- a/src/http_client_macos.mm
+++ b/src/http_client_macos.mm
@@ -147,9 +147,8 @@ public:
                                                               path:str::to_NS(url)
                                                         parameters:nil];
     
-        for(const auto& h : hdrs) {
+        for(const auto& h : hdrs)
             [request addValue:str::to_NS(h.second) forHTTPHeaderField:str::to_NS(h.first)];
-        }
 
         auto body = data.body();
         [request setValue:str::to_NS(data.content_type()) forHTTPHeaderField:@"Content-Type"];

--- a/src/http_client_macos.mm
+++ b/src/http_client_macos.mm
@@ -139,7 +139,7 @@ public:
         return promise->get_future();
     }
 
-    dispatch::future<json> post(const std::string& url, const http_body_data& data, const http_client::hdrs_t& hdrs)
+    dispatch::future<json> post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
     {
         auto promise = std::make_shared<dispatch::promise<json>>();
 
@@ -254,7 +254,7 @@ dispatch::future<void> http_client::download(const std::string& url, const std::
     return m_impl->download(url, output_file);
 }
 
-dispatch::future<json> http_client::post(const std::string& url, const http_body_data& data, const http_client::hdrs_t& hdrs)
+dispatch::future<json> http_client::post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
 {
     return m_impl->post(url, data, hdrs);
 }

--- a/src/http_client_macos.mm
+++ b/src/http_client_macos.mm
@@ -139,13 +139,17 @@ public:
         return promise->get_future();
     }
 
-    dispatch::future<json> post(const std::string& url, const http_body_data& data)
+    dispatch::future<json> post(const std::string& url, const http_body_data& data, const http_client::hdrs_t& hdrs)
     {
         auto promise = std::make_shared<dispatch::promise<json>>();
 
         NSMutableURLRequest *request = [m_native requestWithMethod:@"POST"
                                                               path:str::to_NS(url)
                                                         parameters:nil];
+    
+        for(const auto& h : hdrs) {
+            [request addValue:str::to_NS(h.second) forHTTPHeaderField:str::to_NS(h.first)];
+        }
 
         auto body = data.body();
         [request setValue:str::to_NS(data.content_type()) forHTTPHeaderField:@"Content-Type"];
@@ -250,7 +254,7 @@ dispatch::future<void> http_client::download(const std::string& url, const std::
     return m_impl->download(url, output_file);
 }
 
-dispatch::future<json> http_client::post(const std::string& url, const http_body_data& data)
+dispatch::future<json> http_client::post(const std::string& url, const http_body_data& data, const http_client::hdrs_t& hdrs)
 {
-    return m_impl->post(url, data);
+    return m_impl->post(url, data, hdrs);
 }

--- a/src/version.h
+++ b/src/version.h
@@ -26,7 +26,7 @@
 #ifndef Poedit_version_h
 #define Poedit_version_h
 
-#define POEDIT_VERSION           "2.4.7dev"
-#define POEDIT_VERSION_WIN        2,4,7
+#define POEDIT_VERSION           "2.4.8dev"
+#define POEDIT_VERSION_WIN        2,4,8
 
 #endif // Poedit_version_h

--- a/src/version.h
+++ b/src/version.h
@@ -26,7 +26,7 @@
 #ifndef Poedit_version_h
 #define Poedit_version_h
 
-#define POEDIT_VERSION           "2.3"
-#define POEDIT_VERSION_WIN        2,3,0
+#define POEDIT_VERSION           "2.4.7dev"
+#define POEDIT_VERSION_WIN        2,4,7
 
 #endif // Poedit_version_h

--- a/win32/poedit.iss
+++ b/win32/poedit.iss
@@ -25,12 +25,12 @@
 ;
 
 #ifndef CONFIG
-#define CONFIG           "Release"
+#define CONFIG           "Debug"
 #endif
 
 #include "../" + CONFIG + "/git_build_number.h"
 
-#define VERSION          "2.3"
+#define VERSION          "2.4.7"
 #define VERSION_WIN      VERSION + "." + Str(POEDIT_GIT_BUILD_NUMBER)
 
 #ifndef CRT_REDIST

--- a/win32/poedit.iss
+++ b/win32/poedit.iss
@@ -25,12 +25,12 @@
 ;
 
 #ifndef CONFIG
-#define CONFIG           "Debug"
+#define CONFIG           "Release"
 #endif
 
 #include "../" + CONFIG + "/git_build_number.h"
 
-#define VERSION          "2.4.7"
+#define VERSION          "2.4.9"
 #define VERSION_WIN      VERSION + "." + Str(POEDIT_GIT_BUILD_NUMBER)
 
 #ifndef CRT_REDIST


### PR DESCRIPTION
Added support (from customer's prospective):
- [Crowdin for enterprise](https://crowdin.com/enterprise)
  - Works with Crowdin Enterprise accounts of any organization (on any domains)
- Open/save/sync as Xliff any file which can be parsed for translations by Crowdin 

Improved
- Path to locally stored Crowdin files contains `<project ID> <project name>/<lang code>/<branch><path to file in Crowdin project>`

Migrated to new:
- [OAuth v2](https://support.crowdin.com/enterprise/creating-oauth-app/) 
- [API v2](https://support.crowdin.com/api/v2/)