### PR TITLE
Crowdin API v2, allow editing of any files as XLIFF

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -597,6 +597,9 @@ void Catalog::SetFileName(const wxString& fn)
 {
     wxFileName f(fn);
     f.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE);
+    auto name = f.GetName();
+    name.ToLong(&m_crowdinProjectId);
+    name.AfterFirst('_').ToLong(&m_crowdinFileId);
     m_fileName = f.GetFullPath();
 }
 

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -602,8 +602,10 @@ void Catalog::SetFileName(const wxString& fn)
 
 bool Catalog::IsFromCrowdin() const
 {
-    if((m_crowdinFileId > 0 && m_crowdinProjectId) > 0
-        || (m_header.HasHeader("X-Crowdin-Project") && m_header.HasHeader("X-Crowdin-File")))
+    if (m_crowdinFileId > 0 && m_crowdinProjectId > 0)
+        return true;
+
+    if (m_header.HasHeader("X-Crowdin-Project") && m_header.HasHeader("X-Crowdin-File"))
         return true;
 
     auto name = wxFileName(m_fileName).GetName();

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -597,12 +597,25 @@ void Catalog::SetFileName(const wxString& fn)
 {
     wxFileName f(fn);
     f.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE);
-    auto name = f.GetName();
-    name.ToLong(&m_crowdinProjectId);
-    name.AfterFirst('_').ToLong(&m_crowdinFileId);
     m_fileName = f.GetFullPath();
 }
 
+bool Catalog::IsFromCrowdin() const
+{
+    if((m_crowdinFileId > 0 && m_crowdinProjectId) > 0
+        || (m_header.HasHeader("X-Crowdin-Project") && m_header.HasHeader("X-Crowdin-File")))
+        return true;
+
+    auto name = wxFileName(m_fileName).GetName();
+    if(name.StartsWith("CrowdinSync_"))
+    {
+        name = name.AfterFirst('_');
+        name.ToLong(&m_crowdinProjectId);
+        name.AfterFirst('_').ToLong(&m_crowdinFileId);
+    }
+
+    return m_crowdinFileId > 0 && m_crowdinProjectId > 0;
+}
 
 namespace
 {

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -469,7 +469,7 @@ class Catalog
         Type GetFileType() const { return m_fileType; }
 
         wxString GetFileName() const { return m_fileName; }
-        void SetFileName(const wxString& fn);
+        virtual void SetFileName(const wxString& fn);
 
         /**
             Return base path to source code for extraction, or empty string if not configured.
@@ -552,9 +552,10 @@ class Catalog
         virtual void SetLanguage(Language lang);
 
         /// Is the PO file from Crowdin, i.e. sync-able?
-        bool IsFromCrowdin() const
-            { return m_header.HasHeader("X-Crowdin-Project") && m_header.HasHeader("X-Crowdin-File"); }
-
+        bool IsFromCrowdin() const { return m_crowdinFileId > 0 && m_crowdinProjectId > 0; }
+        long GetCrowdinFileId() const { return m_crowdinFileId; }
+        long GetCrowdinProjectId() const { return m_crowdinProjectId; }
+            
         /// Returns true if the catalog contains obsolete entries (~.*)
         virtual bool HasDeletedItems() const = 0;
 
@@ -594,6 +595,7 @@ class Catalog
         bool m_isOk;
         Type m_fileType;
         wxString m_fileName;
+        long m_crowdinFileId = -1, m_crowdinProjectId = -1;
         HeaderData m_header;
         Language m_sourceLanguage;
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -552,8 +552,7 @@ class Catalog
         virtual void SetLanguage(Language lang);
 
         /// Is the PO file from Crowdin, i.e. sync-able?
-        bool IsFromCrowdin() const { return (m_crowdinFileId > 0 && m_crowdinProjectId > 0) 
-                                            || (m_header.HasHeader("X-Crowdin-Project") && m_header.HasHeader("X-Crowdin-File")); }
+        bool IsFromCrowdin() const;
         long GetCrowdinFileId() const { return m_crowdinFileId; }
         long GetCrowdinProjectId() const { return m_crowdinProjectId; }
         void SetCrowdinProjectAndFileId(int projId, int fileId) { m_crowdinProjectId  = projId; m_crowdinFileId = fileId; }
@@ -597,7 +596,7 @@ class Catalog
         bool m_isOk;
         Type m_fileType;
         wxString m_fileName;
-        long m_crowdinFileId = -1, m_crowdinProjectId = -1;
+        mutable long m_crowdinFileId = -1, m_crowdinProjectId = -1;
         HeaderData m_header;
         Language m_sourceLanguage;
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -469,7 +469,7 @@ class Catalog
         Type GetFileType() const { return m_fileType; }
 
         wxString GetFileName() const { return m_fileName; }
-        virtual void SetFileName(const wxString& fn);
+        void SetFileName(const wxString& fn);
 
         /**
             Return base path to source code for extraction, or empty string if not configured.

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -552,9 +552,11 @@ class Catalog
         virtual void SetLanguage(Language lang);
 
         /// Is the PO file from Crowdin, i.e. sync-able?
-        bool IsFromCrowdin() const { return m_crowdinFileId > 0 && m_crowdinProjectId > 0; }
+        bool IsFromCrowdin() const { return (m_crowdinFileId > 0 && m_crowdinProjectId > 0) 
+                                            || (m_header.HasHeader("X-Crowdin-Project") && m_header.HasHeader("X-Crowdin-File")); }
         long GetCrowdinFileId() const { return m_crowdinFileId; }
         long GetCrowdinProjectId() const { return m_crowdinProjectId; }
+        void SetCrowdinProjectAndFileId(int projId, int fileId) { m_crowdinProjectId  = projId; m_crowdinFileId = fileId; }
             
         /// Returns true if the catalog contains obsolete entries (~.*)
         virtual bool HasDeletedItems() const = 0;

--- a/src/catalog_po.cpp
+++ b/src/catalog_po.cpp
@@ -861,7 +861,7 @@ bool POCatalog::Load(const wxString& po_file, int flags)
 
     Clear();
     m_isOk = false;
-    m_fileName = po_file;
+    SetFileName(po_file);
     m_header.BasePath = wxEmptyString;
 
     wxString ext;

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -608,7 +608,8 @@ void XLIFF1Catalog::Parse(pugi::xml_node root)
         //       (what is always the only case for downloaded from Crowdin)
         //       But should be taken into account and improved for probable
         //       more wide varietty of cases in the future.
-        if(id == 0) {
+        if(id == 0)
+        {
             m_sourceLanguage = Language::TryParse(file.attribute("source-language").value());
             SetLanguage(Language::TryParse(file.attribute("target-language").value()));
         }

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -611,7 +611,7 @@ void XLIFF1Catalog::Parse(pugi::xml_node root)
         if(id == 0)
         {
             m_sourceLanguage = Language::TryParse(file.attribute("source-language").value());
-            SetLanguage(Language::TryParse(file.attribute("target-language").value()));
+            m_language = Language::TryParse(file.attribute("target-language").value());
         }
         
         for (auto unit: file.select_nodes(".//trans-unit"))
@@ -748,7 +748,7 @@ protected:
 void XLIFF2Catalog::Parse(pugi::xml_node root)
 {
     m_sourceLanguage = Language::TryParse(root.attribute("srcLang").value());
-    SetLanguage(Language::TryParse(root.attribute("trgLang").value()));
+    m_language = Language::TryParse(root.attribute("trgLang").value());
 
     int id = 0;
     for (auto segment: root.select_nodes(".//segment"))

--- a/src/catalog_xliff.h
+++ b/src/catalog_xliff.h
@@ -27,6 +27,7 @@
 #define Poedit_catalog_xliff_h
 
 #include "catalog.h"
+#include "cloud_sync.h"
 #include "errors.h"
 
 #include "pugixml.h"
@@ -101,9 +102,6 @@ public:
 
     ValidationResults Validate(bool wasJustLoaded) override;
 
-    Language GetLanguage() const override { return m_language; }
-    void SetLanguage(Language lang) override { m_language = lang; }
-
     // FIXME: PO specific
     bool HasDeletedItems() const override { return false;}
     void RemoveDeletedItems() override {}
@@ -118,7 +116,6 @@ protected:
 
 protected:
     pugi::xml_document m_doc;
-    Language m_language;
 };
 
 

--- a/src/catalog_xliff.h
+++ b/src/catalog_xliff.h
@@ -101,6 +101,9 @@ public:
 
     ValidationResults Validate(bool wasJustLoaded) override;
 
+    Language GetLanguage() const override { return m_language; }
+    void SetLanguage(Language lang) override { m_language = lang; }
+
     // FIXME: PO specific
     bool HasDeletedItems() const override { return false;}
     void RemoveDeletedItems() override {}
@@ -115,6 +118,7 @@ protected:
 
 protected:
     pugi::xml_document m_doc;
+    Language m_language;
 };
 
 

--- a/src/catalog_xliff.h
+++ b/src/catalog_xliff.h
@@ -27,7 +27,6 @@
 #define Poedit_catalog_xliff_h
 
 #include "catalog.h"
-#include "cloud_sync.h"
 #include "errors.h"
 
 #include "pugixml.h"

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -83,6 +83,26 @@ public:
 
         return std::make_shared<Dest>(name, std::move(func));
     }
+
+    static const wxString& GetCacheDir()
+    {
+        static wxString localBaseDir;
+
+        if(localBaseDir.empty()) {
+
+            #if defined(__WXOSX__)
+                localBaseDir = wxGetHomeDir() + "/Library/Caches/net.poedit.Poedit";
+            #elif defined(__UNIX__)
+                if (!wxGetEnv("XDG_CACHE_HOME", &localBaseDir))
+                    localBaseDir = wxGetHomeDir() + "/.cache";
+                localBaseDir += "/poedit";
+            #else
+                localBaseDir = wxStandardPaths::Get().GetUserDataDir() + wxFILE_SEP_PATH + "Cache";
+            #endif
+        }
+
+        return localBaseDir;
+    }
 };
 
 

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -89,7 +89,8 @@ public:
     {
         static wxString localBaseDir;
 
-        if(localBaseDir.empty()) {
+        if(localBaseDir.empty())
+        {
 
             #if defined(__WXOSX__)
                 localBaseDir = wxGetHomeDir() + "/Library/Caches/net.poedit.Poedit";
@@ -137,7 +138,8 @@ public:
     /// Show the window while performing background sync action. Show error if 
     static void RunSync(wxWindow *parent, std::shared_ptr<CloudSyncDestination> dest, CatalogPtr file)
     {
-        if(!dest->Auth(parent)) {
+        if(!dest->Auth(parent))
+        {
             return;
         }
 

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -62,6 +62,7 @@ public:
 
     /// Asynchronously uploads the file. Returned future throws on error.
     virtual dispatch::future<void> Upload(CatalogPtr file) = 0;
+    virtual bool Auth(wxWindow* parent) = 0;
 
 
     /// Convenicence for creating a destination from a lambda.
@@ -136,6 +137,10 @@ public:
     /// Show the window while performing background sync action. Show error if 
     static void RunSync(wxWindow *parent, std::shared_ptr<CloudSyncDestination> dest, CatalogPtr file)
     {
+        if(!dest->Auth(parent)) {
+            return;
+        }
+
         wxWindowPtr<CloudSyncProgressWindow> progress(new CloudSyncProgressWindow(parent, dest));
 #ifdef __WXOSX__
         progress->ShowWindowModal();

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -30,6 +30,7 @@
 #include "concurrency.h"
 
 #include <wx/string.h>
+#include <wx/stdpaths.h>
 
 #if wxUSE_GUI
     #include "customcontrols.h"

--- a/src/cloud_sync.h
+++ b/src/cloud_sync.h
@@ -31,6 +31,7 @@
 
 #include <wx/string.h>
 #include <wx/stdpaths.h>
+#include <wx/utils.h>
 
 #if wxUSE_GUI
     #include "customcontrols.h"

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -44,7 +44,6 @@
 
 #include <iostream>
 
-
 // GCC's libstdc++ didn't have functional std::regex implementation until 4.9
 #if (defined(__GNUC__) && !defined(__clang__) && !wxCHECK_GCC_VERSION(4,9))
     #include <boost/regex.hpp>
@@ -256,7 +255,7 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const int project_id)
 {
     auto url = "projects/" + std::to_string(project_id);
-    auto prj = make_shared<ProjectInfo>();
+    auto prj = std::make_shared<ProjectInfo>();
     enum { NO_ID = -1 };
         
     return m_api->get(url)
@@ -293,10 +292,10 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
     {
         // Handle directories
         struct dir {
-            string name;
+            std::string name;
             int parentId;
         };
-        map<int, dir> dirs;
+        std::map<int, dir> dirs;
 
         for(const auto& i : r["data"]) {
             const json& d = i["data"],
@@ -310,7 +309,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
             });
         }
 
-        stack<string> path;
+        std::stack<std::string> path;
         for(auto& i : prj->files) {
             int dirId = i.dirId;
             while(dirId != NO_ID) {
@@ -318,7 +317,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                 path.push(dir.name);
                 dirId = dir.parentId;
             }
-            string pathStr;
+            std::string pathStr;
             while(path.size()) {
                 pathStr += '/';
                 pathStr += path.top();
@@ -334,11 +333,11 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
     }).then([this, url, prj](json r)
     {
         // Handle branches
-        map<int, string> branches;
+        std::map<int, std::string> branches;
 
         for(const auto& i : r["data"]) {
             const json& d = i["data"];
-            branches[d["id"]] = d["name"].get<string>();
+            branches[d["id"]] = d["name"].get<std::string>();
         }
 
         for(auto& i : prj->files) {

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -196,20 +196,15 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             const json& d = r["data"];
             UserInfo u;
             u.login = str::to_wstring(d["username"]);
-            u.name = str::to_wstring(d.value("fullName", ""));
-            if(u.name.empty())
+            try { u.name = str::to_wstring(d.at("fullName")); }
+            catch(...)
             {
-                // Take care that both first and last name can be empty
-                auto name = d["firstName"];
-                if(name.is_string())
-                    u.name += str::to_wstring(name);
-                if(!u.name.empty())
-                    u.name += ' ';
-                name = d["lastName"];
-                if(name.is_string())
-                    u.name += str::to_wstring(name);
+                std::string firstName, lastName;
+                try { firstName = d.at("firstName"); } catch(...) {}
+                try { lastName = d.at("lastName"); } catch(...) {}
+                u.name = str::to_wstring(firstName + ' ' + lastName);
             }
-            if(u.name.empty())
+            if(u.name.empty() || u.name == L" ")
                 u.name = u.login;
             return u;
         });

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -229,15 +229,21 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
             for (auto&& d : r["data"])
             {
                 const json& i = d["data"];
-                all.push_back({
-                    str::to_wstring(i["name"]),
-                    i["id"].get<int>(),
-                    //TODO: should be tested with project not owning by
-                    //      currently authorized user as well (not only
-                    //      for owning) after it will be implemented in
-                    //      in API v2 (unimplemented yet)
-                    /*(bool)i["publicDownloads"].get<int>()*/true
+                auto itPublicDownloads = i.find("publicDownloads");
+                if(itPublicDownloads != i.end()
+                    // for some wierd reason `publicDownloads` can be in 3 states:
+                    // `null`, `true` and `false` and, as investigated experimentally,
+                    // only `null` means 'Forbidden' to work with project files (to get list etc)
+                    // so hide such projects. While `false` or `true` allows to work with 
+                    // such projects normally
+                    && !itPublicDownloads->is_null()) {
+
+                    all.push_back({
+                        str::to_wstring(i["name"]),
+                        i["id"].get<int>()
                 });
+
+                }
             }
             return all;
         });

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -100,12 +100,24 @@ protected:
     std::string parse_json_error(const json& response) const override
     {
         cout << "\n\nJSON error: " << response << "\n\n";
-        std::string msg = response["error"]["message"];
 
-        // Translate commonly encountered messages:
-        if (msg == "Translations download is forbidden by project owner")
-            msg = _("Downloading translations is disabled in this project.").utf8_str();
-        return msg;
+        try
+        {
+            return response.at("errors").at(0).at("error").at("errors").at(0).at("message");
+        }
+        catch(...)
+        {
+            try
+            {
+                return response.at("error").at("message");
+            }
+            catch (...)
+            {
+                std::string msg;
+                msg = _("JSON request error").utf8_str();
+                return msg;
+            }
+        }
     }
 
     void on_error_response(int& statusCode, std::string& message) override

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -37,6 +37,10 @@
 #include <wx/translation.h>
 #include <wx/utils.h>
 
+#include <iostream>
+
+using namespace std;
+
 // GCC's libstdc++ didn't have functional std::regex implementation until 4.9
 #if (defined(__GNUC__) && !defined(__clang__) && !wxCHECK_GCC_VERSION(4,9))
     #include <boost/regex.hpp>
@@ -88,13 +92,14 @@ std::string CrowdinClient::WrapLink(const std::string& page)
 class CrowdinClient::crowdin_http_client : public http_client
 {
 public:
-    crowdin_http_client(CrowdinClient& owner, const std::string& url_prefix = "")
-        : http_client(url_prefix.empty() ? "https://berezins.crowdin.com/api/v2": url_prefix), m_owner(owner)
+    crowdin_http_client(CrowdinClient& owner, const std::string& url_prefix)
+        : http_client(url_prefix), m_owner(owner)
     {}
 
 protected:
     std::string parse_json_error(const json& response) const override
     {
+        cout << "\n\nJSON error: " << response << "\n\n";
         std::string msg = response["error"]["message"];
 
         // Translate commonly encountered messages:
@@ -111,21 +116,16 @@ protected:
             message = _("Not authorized, please sign in again.").utf8_str();
             m_owner.SignOut();
         }
+        printf("\n\nJSON error: %s\n\n", message.c_str());
     }
 
     CrowdinClient& m_owner;
 };
 
-class CrowdinClient::crowdin_oauth_client : public crowdin_http_client
-{
-public:
-    crowdin_oauth_client(CrowdinClient& owner)
-        : crowdin_http_client(owner, "https://accounts.crowdin.com")
-    {}
-};
-
-
-CrowdinClient::CrowdinClient() : m_api(new crowdin_http_client(*this)), m_oauth(new crowdin_oauth_client(*this))
+CrowdinClient::CrowdinClient() :
+    m_api(new crowdin_http_client(*this, "https://serhiy.crowdin.com/api/v2")),
+    m_oauth(new crowdin_http_client(*this, "https://accounts.crowdin.com")),
+    m_downloader(new crowdin_http_client(*this, "https://production-enterprise-tmp.downloads.crowdin.com")) 
 {
     SignInIfAuthorized();
 }
@@ -170,16 +170,23 @@ bool CrowdinClient::IsOAuthCallback(const std::string& uri)
     return boost::starts_with(uri, OAUTH_URI_PREFIX);
 }
 
+//TODO: validate JSON schema in all API responses
+//      and handle errors since now Poedit just crashes
+//      in case of some of expected keys missing
 
 dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
 {
     return m_api->get("/user")
         .then([](json r)
         {
+            cout << "\n\nGot user info: " << r << "\n\n";
             const json& d = r["data"];
             UserInfo u;
             u.login = str::to_wstring(d["username"]);
-            u.name =  str::to_wstring(d["firstName"]) + " " +  str::to_wstring(d["lastName"]);
+            u.name = str::to_wstring(d.value("fullName", ""));
+            if(u.name.empty()) {
+                u.name = str::to_wstring(d["firstName"]) + " " + str::to_wstring(d["lastName"]);
+            }
             if(u.name.empty()) {
                 u.name = u.login;
             }
@@ -190,16 +197,24 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
 
 dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetUserProjects()
 {
-    return m_api->get("/api/account/get-projects?json=&role=all")
+    // TODO: handle pagination if projects more than 500
+    //       (what is quite rare case I guess)
+    return m_api->get("/projects?limit=500")
         .then([](json r)
         {
+            cout << "\n\nGot projects: " << r << endl<<endl;
             std::vector<ProjectListing> all;
-            for (auto i : r["projects"])
+            for (auto&& d : r["data"])
             {
+                const json& i = d["data"];
                 all.push_back({
                     str::to_wstring(i["name"]),
-                    i["identifier"],
-                    (bool)i["downloadable"].get<int>()
+                    i["id"].get<int>(),
+                    //TODO: should be tested with project not owning by
+                    //      currently authorized user as well (not only
+                    //      for owning) after it will be implemented in
+                    //      in API v2 (unimplemented yet)
+                    /*(bool)i["publicDownloads"].get<int>()*/true
                 });
             }
             return all;
@@ -207,39 +222,51 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 }
 
 
-dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const std::string& project_id)
+dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const int project_id)
 {
-    auto url = "/api/project/" + project_id + "/info?json=&project-identifier=" + project_id;
+    auto url = "/projects/" + std::to_string(project_id);
     return m_api->get(url)
-        .then([](json r){
+        .then([this, url](json r)
+        {
             ProjectInfo prj;
-            auto details = r["details"];
-            prj.name = str::to_wstring(details["name"]);
-            prj.identifier = details["identifier"];
-            for (auto i : r["languages"])
-            {
-                if (i["can_translate"].get<int>() != 0)
-                    prj.languages.push_back(Language::TryParse(str::to_wstring(i["code"])));
+            const json& d = r["data"];
+            prj.name = str::to_wstring(d["name"]);
+            prj.id = d["id"];
+            for (auto&& langCode : d["targetLanguageIds"]) {
+                prj.languages.push_back(Language::TryParse(str::to_wstring(langCode)));
             }
-            ExtractFilesFromInfo(prj.files, r, L"/");
-            return prj;
+            return m_api->get(url + "/files?limit=500")
+                .then([prj_ = prj](json r)
+                {
+                    auto prj = prj_;
+                    //TODO: files should be with full path
+                    for(auto&& i : r["data"]) {
+                        const json& d = i["data"];
+                        prj.files.push_back({L"/" + str::to_wstring(d["name"]), d["id"]});
+                    }
+                    //TODO: get more until all files gotten (if more than 500)
+                    return prj;
+                });
         });
 }
 
 
-dispatch::future<void> CrowdinClient::DownloadFile(const std::string& project_id,
-                                                   const std::wstring& file,
-                                                   const Language& lang,
+dispatch::future<void> CrowdinClient::DownloadFile(const int project_id,
+                                                   const int file_id,
+                                                   const std::wstring& lang_tag,
                                                    const std::wstring& output_file)
 {
-    // NB: "export_translated_only" means the translation is not filled with the source string
-    //     if there's no translation, i.e. what Poedit wants.
-    auto url = "/api/project/" + project_id + "/export-file"
-                   "?json="
-                   "&export_translated_only=1"
-                   "&language=" + lang.LanguageTag() +
-                   "&file=" + http_client::url_encode(file);
-    return m_api->download(url, output_file);
+    cout << "\n\nGetting file URL: " << "/projects/" + std::to_string(project_id) + "/files/" + std::to_string(file_id) + "/download" << "\n\n";
+    return m_api->post(
+        "/projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
+        json_data(json({
+            { "targetLanguageId", str::to_utf8(lang_tag) },
+            { "exportAsXliff", true }
+        })))
+        .then([this, output_file] (json r) {
+            cout << "\n\nGotten file URL: "<< r << "\n\n";
+            return m_downloader->download(r["data"]["url"], output_file);
+        });
 }
 
 
@@ -256,7 +283,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const std::string& project_id,
     data.add_value("import_duplicates", "0");
     data.add_value("import_eq_suggestions", "0");
     data.add_file("files[" + str::to_utf8(file) + "]", "upload.po", file_content);
-
+    
     return m_api->post(url, data).then([](json){});
 }
 
@@ -273,6 +300,7 @@ void CrowdinClient::SignInIfAuthorized()
     std::string token;
     if (keytar::GetPassword("Crowdin", "", &token))
         SetToken(token);
+    cout << "\n\nToken: "<<token<<"\n\n";
 }
 
 

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -184,7 +184,18 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             u.login = str::to_wstring(d["username"]);
             u.name = str::to_wstring(d.value("fullName", ""));
             if(u.name.empty()) {
-                u.name = str::to_wstring(d["firstName"]) + " " + str::to_wstring(d["lastName"]);
+                // Take care that both first and last name can be empty
+                auto name = d["firstName"];
+                if(name.is_string()) {
+                    u.name += str::to_wstring(name);
+                }
+                if(!u.name.empty()) {
+                    u.name += ' ';
+                }
+                name = d["lastName"];
+                if(name.is_string()) {
+                    u.name += str::to_wstring(name);
+                }
             }
             if(u.name.empty()) {
                 u.name = u.login;

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -283,7 +283,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const std::string& project_id,
     data.add_value("import_duplicates", "0");
     data.add_value("import_eq_suggestions", "0");
     data.add_file("files[" + str::to_utf8(file) + "]", "upload.po", file_content);
-    
+
     return m_api->post(url, data).then([](json){});
 }
 

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -197,23 +197,20 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             UserInfo u;
             u.login = str::to_wstring(d["username"]);
             u.name = str::to_wstring(d.value("fullName", ""));
-            if(u.name.empty()) {
+            if(u.name.empty())
+            {
                 // Take care that both first and last name can be empty
                 auto name = d["firstName"];
-                if(name.is_string()) {
+                if(name.is_string())
                     u.name += str::to_wstring(name);
-                }
-                if(!u.name.empty()) {
+                if(!u.name.empty())
                     u.name += ' ';
-                }
                 name = d["lastName"];
-                if(name.is_string()) {
+                if(name.is_string())
                     u.name += str::to_wstring(name);
-                }
             }
-            if(u.name.empty()) {
+            if(u.name.empty())
                 u.name = u.login;
-            }
             return u;
         });
 }
@@ -265,17 +262,18 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         const json& d = r["data"];
         prj->name = str::to_wstring(d["name"]);
         prj->id = d["id"];
-        for (const auto& langCode : d["targetLanguageIds"]) {
+        for (const auto& langCode : d["targetLanguageIds"])
             prj->languages.push_back(Language::TryParse(str::to_wstring(langCode)));
-        }
         //TODO: get more until all files gotten (if more than 500)
         return m_api->get(url + "/files?limit=500");
     }).then([this, url, prj](json r)
     {   
         // Handle project files
-        for(auto& i : r["data"]) {
+        for(auto& i : r["data"])
+        {
             const json& d = i["data"];
-            if(d["type"] != "assets") {
+            if(d["type"] != "assets")
+            {
                 const json& dir = d["directoryId"],
                             branch = d["branchId"];
                 prj->files.push_back({
@@ -297,7 +295,8 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         };
         std::map<int, dir> dirs;
 
-        for(const auto& i : r["data"]) {
+        for(const auto& i : r["data"])
+        {
             const json& d = i["data"],
                   parent = d["directoryId"];
             dirs.insert({
@@ -310,22 +309,24 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         }
 
         std::stack<std::string> path;
-        for(auto& i : prj->files) {
+        for(auto& i : prj->files)
+        {
             int dirId = i.dirId;
-            while(dirId != NO_ID) {
+            while(dirId != NO_ID)
+            {
                 const auto& dir = dirs[dirId];
                 path.push(dir.name);
                 dirId = dir.parentId;
             }
             std::string pathStr;
-            while(path.size()) {
+            while(path.size())
+            {
                 pathStr += '/';
                 pathStr += path.top();
                 path.pop();
             }
-            if(!pathStr.empty()) {
+            if(!pathStr.empty())
                 i.pathName = str::to_wstring(pathStr) + i.pathName;
-            }
         }
 
         //TODO: get more until all branches gotten (if more than 500)    
@@ -335,16 +336,15 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         // Handle branches
         std::map<int, std::string> branches;
 
-        for(const auto& i : r["data"]) {
+        for(const auto& i : r["data"])
+        {
             const json& d = i["data"];
             branches[d["id"]] = d["name"].get<std::string>();
         }
 
-        for(auto& i : prj->files) {
-            if(i.branchId != NO_ID) {
+        for(auto& i : prj->files)
+            if(i.branchId != NO_ID)
                 i.pathName = "/" + str::to_wstring(branches[i.branchId]) + i.pathName;
-            }
-        }
 
         return *prj;
     });

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -32,6 +32,10 @@
 
 #include <functional>
 #include <mutex>
+#include <stack>
+#include <iostream>
+#include <ctime>
+
 #include <boost/algorithm/string.hpp>
 
 #include <wx/translation.h>
@@ -226,7 +230,7 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
         {
             cout << "\n\nGot projects: " << r << endl<<endl;
             std::vector<ProjectListing> all;
-            for (auto&& d : r["data"])
+            for (const auto& d : r["data"])
             {
                 const json& i = d["data"];
                 auto itPublicDownloads = i.find("publicDownloads");
@@ -253,31 +257,99 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const int project_id)
 {
     auto url = "projects/" + std::to_string(project_id);
+    auto prj = make_shared<ProjectInfo>();
+    enum { NO_ID = -1 };
+        
     return m_api->get(url)
-        .then([this, url](json r)
-        {
-            ProjectInfo prj;
-            const json& d = r["data"];
-            prj.name = str::to_wstring(d["name"]);
-            prj.id = d["id"];
-            for (auto&& langCode : d["targetLanguageIds"]) {
-                prj.languages.push_back(Language::TryParse(str::to_wstring(langCode)));
-            }
-            return m_api->get(url + "/files?limit=500")
-                .then([prj_ = prj](json r)
-                {
-                    auto prj = prj_;
-                    //TODO: files should be with full path
-                    for(auto&& i : r["data"]) {
-                        const json& d = i["data"];
-                        if(d["type"] != "assets") {
-                            prj.files.push_back({L"/" + str::to_wstring(d["name"]), d["id"]});
-                        }
-                    }
-                    //TODO: get more until all files gotten (if more than 500)
-                    return prj;
+    .then([this, url, prj](json r)
+    {
+        // Handle project info
+        const json& d = r["data"];
+        prj->name = str::to_wstring(d["name"]);
+        prj->id = d["id"];
+        for (const auto& langCode : d["targetLanguageIds"]) {
+            prj->languages.push_back(Language::TryParse(str::to_wstring(langCode)));
+        }
+        //TODO: get more until all files gotten (if more than 500)
+        return m_api->get(url + "/files?limit=500");
+    }).then([this, url, prj](json r)
+    {   
+        // Handle project files
+        for(auto& i : r["data"]) {
+            const json& d = i["data"];
+            if(d["type"] != "assets") {
+                const json& dir = d["directoryId"],
+                            branch = d["branchId"];
+                prj->files.push_back({
+                    L"/" + str::to_wstring(d["name"]),
+                    d["id"],
+                    dir.is_null() ? NO_ID : dir.get<int>(),
+                    branch.is_null() ? NO_ID : branch.get<int>()
                 });
-        });
+            }
+        }
+        //TODO: get more until all dirs gotten (if more than 500)
+        return m_api->get(url + "/directories?limit=500");
+    }).then([this, url, prj](json r)
+    {
+        // Handle directories
+        struct dir {
+            string name;
+            int parentId;
+        };
+        map<int, dir> dirs;
+
+        for(const auto& i : r["data"]) {
+            const json& d = i["data"],
+                  parent = d["directoryId"];
+            dirs.insert({
+                d["id"],
+                {
+                    d["name"],
+                    parent.is_null() ? NO_ID : parent.get<int>()
+                }
+            });
+        }
+
+        stack<string> path;
+        for(auto& i : prj->files) {
+            int dirId = i.dirId;
+            while(dirId != NO_ID) {
+                const auto& dir = dirs[dirId];
+                path.push(dir.name);
+                dirId = dir.parentId;
+            }
+            string pathStr;
+            while(path.size()) {
+                pathStr += '/';
+                pathStr += path.top();
+                path.pop();
+            }
+            if(!pathStr.empty()) {
+                i.pathName = str::to_wstring(pathStr) + i.pathName;
+            }
+        }
+
+        //TODO: get more until all branches gotten (if more than 500)    
+        return m_api->get(url + "/branches?limit=500");
+    }).then([this, url, prj](json r)
+    {
+        // Handle branches
+        map<int, string> branches;
+
+        for(const auto& i : r["data"]) {
+            const json& d = i["data"];
+            branches[d["id"]] = d["name"].get<string>();
+        }
+
+        for(auto& i : prj->files) {
+            if(i.branchId != NO_ID) {
+                i.pathName = "/" + str::to_wstring(branches[i.branchId]) + i.pathName;
+            }
+        }
+
+        return *prj;
+    });
 }
 
 

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -252,7 +252,9 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                     //TODO: files should be with full path
                     for(auto&& i : r["data"]) {
                         const json& d = i["data"];
-                        prj.files.push_back({L"/" + str::to_wstring(d["name"]), d["id"]});
+                        if(d["type"] != "assets") {
+                            prj.files.push_back({L"/" + str::to_wstring(d["name"]), d["id"]});
+                        }
                     }
                     //TODO: get more until all files gotten (if more than 500)
                     return prj;

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -187,7 +187,7 @@ bool CrowdinClient::IsOAuthCallback(const std::string& uri)
 
 dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
 {
-    return m_api->get("/user")
+    return m_api->get("user")
         .then([](json r)
         {
             cout << "\n\nGot user info: " << r << "\n\n";
@@ -221,7 +221,7 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 {
     // TODO: handle pagination if projects more than 500
     //       (what is quite rare case I guess)
-    return m_api->get("/projects?limit=500")
+    return m_api->get("projects?limit=500")
         .then([](json r)
         {
             cout << "\n\nGot projects: " << r << endl<<endl;
@@ -246,7 +246,7 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 
 dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const int project_id)
 {
-    auto url = "/projects/" + std::to_string(project_id);
+    auto url = "projects/" + std::to_string(project_id);
     return m_api->get(url)
         .then([this, url](json r)
         {
@@ -283,7 +283,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
 {
     cout << "\n\nGetting file URL: " << "/projects/" + std::to_string(project_id) + "/files/" + std::to_string(file_id) + "/download" << "\n\n";
     return m_api->post(
-        "/projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
+        "projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
         json_data(json({
             { "targetLanguageId", lang_tag },
             // for XLIFF files should be exported "as is" so set to `false`
@@ -302,7 +302,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                                                  const std::string& file_content)
 {
     return m_api->post(
-            "/storages",
+            "storages",
             octet_stream_data(file_content),
             { { "Crowdin-API-FileName", "poedit.xliff"} }
         )
@@ -310,7 +310,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
             cout << "File uploaded to temporary storage: " << r << "\n\n";
             const auto storageId = r["data"]["id"].get<int>();
             return m_api->post(
-                "/projects/" + std::to_string(project_id) + "/translations/" + lang.LanguageTag(),
+                "projects/" + std::to_string(project_id) + "/translations/" + lang.LanguageTag(),
                 json_data(json({
                     { "storageId", storageId },
                     { "fileId", file_id },

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -179,7 +179,6 @@ void CrowdinClient::HandleOAuthCallback(const std::string& uri)
     m_authCallback.reset();
 }
 
-
 bool CrowdinClient::IsOAuthCallback(const std::string& uri)
 {
     return boost::starts_with(uri, OAUTH_URI_PREFIX);
@@ -362,7 +361,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
     cout << "\n\nGetting file URL: " << "/projects/" + std::to_string(project_id) + "/files/" + std::to_string(file_id) + "/download" << "\n\n";
     return m_api->post(
         "projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
-        json_data(json({
+        json_data({
             { "targetLanguageId", lang_tag },
             // for XLIFF files should be exported "as is" so set to `false`
             { "exportAsXliff", !wxString(file_name).Lower().EndsWith(".xliff.xliff") }
@@ -398,12 +397,12 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
             const auto storageId = r["data"]["id"].get<int>();
             return m_api->post(
                 "projects/" + std::to_string(project_id) + "/translations/" + lang.LanguageTag(),
-                json_data(json({
+                json_data({
                     { "storageId", storageId },
                     { "fileId", file_id },
                     { "importDuplicates", true },
                     { "autoApproveImported", true }
-                })))
+                }))
                 .then([](json r) {
                     cout << "File uploaded: " << r << "\n\n";
                 });

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -234,9 +234,9 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 
                     all.push_back({
                         str::to_wstring(i["name"]),
+                        i["identifier"].get<std::string>(),
                         i["id"].get<int>()
-                });
-
+                    });
                 }
             }
             return all;

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -194,8 +194,8 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             catch(...)
             {
                 std::string firstName, lastName;
-                try { firstName = d.at("firstName").get<std::string>(); } catch(...) {}
-                try { lastName = d.at("lastName").get<std::string>(); } catch(...) {}
+                try { firstName = d.at("firstName"); } catch(...) {}
+                try { lastName = d.at("lastName"); } catch(...) {}
                 u.name = str::to_wstring(firstName + ' ' + lastName);
             }
             if(u.name.empty() || u.name == L" ")
@@ -228,8 +228,8 @@ dispatch::future<std::vector<CrowdinClient::ProjectListing>> CrowdinClient::GetU
 
                     all.push_back({
                         str::to_wstring(i["name"]),
-                        i["identifier"].get<std::string>(),
-                        i["id"].get<int>()
+                        i["identifier"],
+                        i["id"]
                     });
                 }
             }
@@ -268,8 +268,8 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                 prj->files.push_back({
                     L"/" + str::to_wstring(d["name"]),
                     d["id"],
-                    dir.is_null() ? NO_ID : dir.get<int>(),
-                    branch.is_null() ? NO_ID : branch.get<int>()
+                    dir.is_null() ? NO_ID : dir,
+                    branch.is_null() ? NO_ID : branch
                 });
             }
         }
@@ -292,7 +292,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                 d["id"],
                 {
                     d["name"],
-                    parent.is_null() ? NO_ID : parent.get<int>()
+                    parent.is_null() ? NO_ID : parent
                 }
             });
         }
@@ -328,7 +328,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
         for(const auto& i : r["data"])
         {
             const json& d = i["data"];
-            branches[d["id"]] = d["name"].get<std::string>();
+            branches[d["id"]] = d["name"];
         }
 
         for(auto& i : prj->files)
@@ -386,7 +386,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
         )
         .then([this, project_id, file_id, lang] (json r) {
             wxLogTrace("poedit.crowdin", "File uploaded to temporary storage: %s", r.dump().c_str());
-            const auto storageId = r["data"]["id"].get<int>();
+            const auto storageId = r["data"]["id"];
             return m_api->post(
                 "projects/" + std::to_string(project_id) + "/translations/" + lang.LanguageTag(),
                 json_data({
@@ -464,7 +464,7 @@ void CrowdinClient::SetToken(const std::string& token)
         domain = json::parse(
             base64_decode_json_part(std::string(
                 wxString(token).AfterFirst('.').BeforeFirst('.').utf8_str()
-        ))).at("domain").get<std::string>();
+        ))).at("domain");
         domain += ".";
     }
     catch(...) {}

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -70,7 +70,7 @@ namespace
 {
 
 #define OAUTH_SCOPE                     "project"
-#define OAUTH_CLIENT_ID                 "k0uFz5HYQh0VzWgZmOpA"
+#define OAUTH_CLIENT_ID                 "6Xsr0OCnsRdALYSHQlvs"
 // Urchin Tracker Module (params for Web analytics package that served as the base for Google Analytics)
 #define UTM_PARAMS                      "utm_source=poedit.net&utm_medium=referral&utm_campaign=poedit"
 // "Authorization Callback URL" field/param set on creating of Crowdin application

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -352,7 +352,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
                                                    const std::string& file_extension,
                                                    const std::wstring& output_file)
 {
-    wxLogTrace("poedit.crowdin", "Getting file URL: projects/%ld/translations/builds/files/%ld", project_id, file_id);
+    wxLogTrace("poedit.crowdin", "DownloadFile(project_id=%ld, lang=%s, file_id=%ld, file_extension=%s, output_file=%S)", project_id, lang.LanguageTag(), file_id, file_extension.c_str(), output_file.c_str());
     wxString ext(file_extension);
     ext.MakeLower();
     return m_api->post(
@@ -384,6 +384,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                                                  const std::string& file_extension,
                                                  const std::string& file_content)
 {
+    wxLogTrace("poedit.crowdin", "UploadFile(project_id=%ld, lang=%s, file_id=%ld, file_extension=%s)", project_id, lang.LanguageTag().c_str(), file_id, file_extension.c_str());
     return m_api->post(
             "storages",
             octet_stream_data(file_content),

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -369,7 +369,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
         json_data({
             { "targetLanguageId", lang.LanguageTag() },
             // for XLIFF and PO files should be exported "as is" so set to `false`
-            { "exportAsXliff", !(ext == "xliff" || ext == "xlf" || ext == "po") }
+            { "exportAsXliff", !(ext == "xliff" || ext == "xlf" || ext == "po" || ext == "pot") }
         }))
         .then([this, output_file] (json r) {
             std::string url = r["data"]["url"];

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -486,7 +486,7 @@ void CrowdinClient::SetToken(const std::string& token)
             domain += '.';
         }
         catch(...) { wxLogTrace("poedit.crowdin", "Assume below token is non-enterprise, fall through with empty domain\n%s", token_json.dump().c_str()); }
-        m_api = std::make_unique<crowdin_http_client>(*this, "https://" + domain + "crowdin.com/api/v2");
+        m_api = std::make_unique<crowdin_http_client>(*this, "https://" + domain + "crowdin.com/api/v2/");
         m_api->set_authorization("Bearer " + token);
     }
     catch(...) { wxLogTrace("poedit.crowdin", "Failed to decode token. Most probable invalid/corrupted or unknown/unsupported type", token.c_str()); }

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -266,7 +266,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                 const json& dir = d["directoryId"],
                             branch = d["branchId"];
                 prj->files.push_back({
-                    L"/" + str::to_wstring(d["name"]),
+                    L'/' + str::to_wstring(d["name"]),
                     d["id"],
                     dir.is_null() ? NO_ID : dir,
                     branch.is_null() ? NO_ID : branch
@@ -333,7 +333,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
 
         for(auto& i : prj->files)
             if(i.branchId != NO_ID)
-                i.pathName = "/" + str::to_wstring(branches[i.branchId]) + i.pathName;
+                i.pathName = L'/' + str::to_wstring(branches[i.branchId]) + i.pathName;
 
         return *prj;
     });
@@ -465,7 +465,7 @@ void CrowdinClient::SetToken(const std::string& token)
             base64_decode_json_part(std::string(
                 wxString(token).AfterFirst('.').BeforeFirst('.').utf8_str()
         ))).at("domain");
-        domain += ".";
+        domain += '.';
     }
     catch(...) {}
     m_api = std::make_unique<crowdin_http_client>(*this, "https://" + domain + "crowdin.com/api/v2");

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -397,8 +397,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                 json_data({
                     { "storageId", storageId },
                     { "fileId", file_id },
-                    { "importDuplicates", true },
-                    { "autoApproveImported", true }
+                    { "importDuplicates", true }
                 }))
                 .then([](json r) {
                     wxLogTrace("poedit.crowdin", "File uploaded: %s", r.dump().c_str());

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -66,7 +66,7 @@
 namespace
 {
 
-#define OAUTH_SCOPE         "project+tm"
+#define OAUTH_SCOPE         "project"
 #define OAUTH_CLIENT_ID     "k0uFz5HYQh0VzWgZmOpA"
 //      any arbitrary unique unguessable string (e.g. UUID in hex)
 #define OAUTH_STATE         "948cf13ffffb47119d6cfa2b68898f67"

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -377,7 +377,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
             // Per download (local) client must be created since different domain
             // per request is not allowed by HTTP client backend on some platorms.
             // (e.g. on Linux).
-            auto downloader = std::make_shared<crowdin_http_client>(*this, std::string((uri.GetScheme() + "://" + uri.GetServer()).mb_str()));
+            auto downloader = std::make_shared<crowdin_http_client>(*this, str::to_utf8(uri.GetScheme() + "://" + uri.GetServer()));
             wxLogTrace("poedit.crowdin", "Gotten file URL: %s", r.dump().c_str());
             // Below capturing of `[downloader]` is needed to preserve `downloader` object
             // from being destroyed before `download(...)` completes asynchroneously

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -360,7 +360,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
         json_data({
             { "targetLanguageId", lang.LanguageTag() },
             // for XLIFF and PO files should be exported "as is" so set to `false`
-            { "exportAsXliff", !(ext == "xliff" || ext == "po") }
+            { "exportAsXliff", !(ext == "xliff" || ext == "xlf" || ext == "po") }
         }))
         .then([this, output_file] (json r) {
             std::string url = r["data"]["url"];

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -396,8 +396,7 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
                 "projects/" + std::to_string(project_id) + "/translations/" + lang.LanguageTag(),
                 json_data({
                     { "storageId", storageId },
-                    { "fileId", file_id },
-                    { "importDuplicates", true }
+                    { "fileId", file_id }
                 }))
                 .then([](json r) {
                     wxLogTrace("poedit.crowdin", "File uploaded: %s", r.dump().c_str());

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -195,16 +195,26 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             const json& d = r["data"];
             UserInfo u;
             u.login = str::to_wstring(d["username"]);
-            try { u.name = str::to_wstring(d.at("fullName")); }
-            catch(...)
+            std::string fullName;
+            try { fullName = d.at("fullName"); } // if indvidual (not enterprise) account 
+            catch(...) // or enterpise otherwise
             {
-                std::string firstName, lastName;
-                try { firstName = d.at("firstName"); } catch(...) {}
-                try { lastName = d.at("lastName"); } catch(...) {}
-                u.name = str::to_wstring(firstName + ' ' + lastName);
+                try { fullName = d.at("firstName"); } catch(...) {}
+                try
+                {
+                    std::string lastName = d.at("lastName");
+                    if(!lastName.empty())
+                    {
+                        if(!fullName.empty())
+                            fullName += " ";
+                        fullName += lastName;
+                    }
+                } catch(...) {}
             }
-            if(u.name.empty() || u.name == L" ")
+            if(fullName.empty())
                 u.name = u.login;
+            else
+                u.name = str::to_wstring(fullName);
             return u;
         });
 }

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -247,7 +247,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
 {
     auto url = "projects/" + std::to_string(project_id);
     auto prj = std::make_shared<ProjectInfo>();
-    enum { NO_ID = -1 };
+    enum : int { NO_ID = -1 };
         
     return m_api->get(url)
     .then([this, url, prj](json r)
@@ -273,8 +273,8 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                 prj->files.push_back({
                     L'/' + str::to_wstring(d["name"]),
                     d["id"],
-                    dir.is_null() ? NO_ID : dir,
-                    branch.is_null() ? NO_ID : branch
+                    dir.is_null() ? NO_ID : int(dir),
+                    branch.is_null() ? NO_ID : int(branch)
                 });
             }
         }
@@ -297,7 +297,7 @@ dispatch::future<CrowdinClient::ProjectInfo> CrowdinClient::GetProjectInfo(const
                 d["id"],
                 {
                     d["name"],
-                    parent.is_null() ? NO_ID : parent
+                    parent.is_null() ? NO_ID : int(parent)
                 }
             });
         }

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -200,8 +200,8 @@ dispatch::future<CrowdinClient::UserInfo> CrowdinClient::GetUserInfo()
             catch(...)
             {
                 std::string firstName, lastName;
-                try { firstName = d.at("firstName"); } catch(...) {}
-                try { lastName = d.at("lastName"); } catch(...) {}
+                try { firstName = d.at("firstName").get<std::string>(); } catch(...) {}
+                try { lastName = d.at("lastName").get<std::string>(); } catch(...) {}
                 u.name = str::to_wstring(firstName + ' ' + lastName);
             }
             if(u.name.empty() || u.name == L" ")
@@ -363,7 +363,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(const long project_id,
             { "exportAsXliff", !(ext == "xliff" || ext == "po") }
         }))
         .then([this, output_file] (json r) {
-            std::string url(r["data"]["url"]);
+            std::string url = r["data"]["url"];
             wxURI uri(url);
             // Per download (local) client must be created since different domain
             // per request is not allowed by HTTP client backend on some platorms.
@@ -466,7 +466,7 @@ void CrowdinClient::SetToken(const std::string& token)
         domain = json::parse(
             base64_decode_json_part(std::string(
                 wxString(token).AfterFirst('.').BeforeFirst('.').utf8_str()
-        ))).at("domain");
+        ))).at("domain").get<std::string>();
         domain += ".";
     }
     catch(...) {}

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -93,12 +93,17 @@ protected:
         
         try
         {
+            // Like e.g. on 400 here https://support.crowdin.com/api/v2/#operation/api.projects.getMany
+            // where "key" is usually "error" as figured out while looking in responses with above code
+            // on most API requests used here
             return response.at("errors").at(0).at("error").at("errors").at(0).at("message");
         }
         catch(...)
         {
             try
             {
+                // Like e.g. on 401 here https://support.crowdin.com/api/v2/#operation/api.user.get
+                // as well as in most other requests on above error code
                 return response.at("error").at("message");
             }
             catch (...)

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -409,15 +409,20 @@ dispatch::future<void> CrowdinClient::UploadFile(const long project_id,
 bool CrowdinClient::IsSignedIn() const
 {
     std::string token;
-    return keytar::GetPassword("Crowdin", "", &token);
+    return keytar::GetPassword("Crowdin", "", &token)
+        && token.substr(0, 2) == "2:";
 }
 
 
 void CrowdinClient::SignInIfAuthorized()
 {
     std::string token;
-    if (keytar::GetPassword("Crowdin", "", &token))
+    if (keytar::GetPassword("Crowdin", "", &token)
+        && token.length() > 2)
+    {
+        token = token.substr(2);
         SetToken(token);
+    }
     wxLogTrace("poedit.crowdin", "Token: %s", token.c_str());
 }
 
@@ -477,7 +482,7 @@ void CrowdinClient::SetToken(const std::string& token)
 void CrowdinClient::SaveAndSetToken(const std::string& token)
 {
     SetToken(token);
-    keytar::AddPassword("Crowdin", "", token);
+    keytar::AddPassword("Crowdin", "", "2:" + token);
 }
 
 

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -129,7 +129,7 @@ private:
     void SaveAndSetToken(const std::string& token);
 
     class crowdin_http_client;
-    std::unique_ptr<crowdin_http_client> m_api, m_oauth, m_downloader;
+    std::unique_ptr<crowdin_http_client> m_api, m_oauth;
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
 
     static CrowdinClient *ms_instance;

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -120,7 +120,9 @@ private:
     void SaveAndSetToken(const std::string& token);
 
     class crowdin_http_client;
+    class crowdin_oauth_client;
     std::unique_ptr<crowdin_http_client> m_api;
+    std::unique_ptr<crowdin_oauth_client> m_oauth;
 
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
 

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -80,29 +80,38 @@ public:
     struct ProjectListing
     {
         std::wstring name;
-        std::string identifier;
+        int id;
         bool downloadable;
     };
 
     /// Retrieve listing of projects accessible to the user
     dispatch::future<std::vector<ProjectListing>> GetUserProjects();
 
+    // File information
+    struct FileInfo
+    {
+        std::wstring pathName;
+        int id;
+        
+    };
+
+
     /// Project detailed information
     struct ProjectInfo
     {
         std::wstring name;
-        std::string identifier;
+        int id;
         std::vector<Language> languages;
-        std::vector<std::wstring> files;
+        std::vector<FileInfo> files;
     };
 
     /// Retrieve listing of projects accessible to the user
-    dispatch::future<ProjectInfo> GetProjectInfo(const std::string& project_id);
+    dispatch::future<ProjectInfo> GetProjectInfo(const int project_id);
 
     /// Asynchronously download specific Crowdin file into @a output_file.
-    dispatch::future<void> DownloadFile(const std::string& project_id,
-                                        const std::wstring& file,
-                                        const Language& lang,
+    dispatch::future<void> DownloadFile(const int project_id,
+                                        const int file_id,
+                                        const std::wstring& lang_tag,
                                         const std::wstring& output_file);
 
     /// Asynchronously upload specific Crowdin file data.
@@ -120,10 +129,7 @@ private:
     void SaveAndSetToken(const std::string& token);
 
     class crowdin_http_client;
-    class crowdin_oauth_client;
-    std::unique_ptr<crowdin_http_client> m_api;
-    std::unique_ptr<crowdin_oauth_client> m_oauth;
-
+    std::unique_ptr<crowdin_http_client> m_api, m_oauth, m_downloader;
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
 
     static CrowdinClient *ms_instance;

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -81,7 +81,6 @@ public:
     {
         std::wstring name;
         int id;
-        bool downloadable;
     };
 
     /// Retrieve listing of projects accessible to the user

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -90,7 +90,7 @@ public:
     struct FileInfo
     {
         std::wstring pathName;
-        int id;
+        int id, dirId, branchId;
         
     };
 

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -109,14 +109,15 @@ public:
     dispatch::future<ProjectInfo> GetProjectInfo(const int project_id);
 
     /// Asynchronously download specific Crowdin file into @a output_file.
-    dispatch::future<void> DownloadFile(const int project_id,
-                                        const int file_id,
-                                        const std::wstring& lang_tag,
+    dispatch::future<void> DownloadFile(const long project_id,
+                                        const long file_id,
+                                        const std::wstring& file_name,
+                                        const std::string& lang_tag,
                                         const std::wstring& output_file);
 
     /// Asynchronously upload specific Crowdin file data.
-    dispatch::future<void> UploadFile(const std::string& project_id,
-                                      const std::wstring& file,
+    dispatch::future<void> UploadFile(const long project_id,
+                                      const long file_id,
                                       const Language& lang,
                                       const std::string& file_content);
 

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -80,6 +80,7 @@ public:
     struct ProjectListing
     {
         std::wstring name;
+        std::string identifier;
         int id;
     };
 

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -109,15 +109,16 @@ public:
 
     /// Asynchronously download specific Crowdin file into @a output_file.
     dispatch::future<void> DownloadFile(const long project_id,
+                                        const Language& lang,
                                         const long file_id,
-                                        const std::wstring& file_name,
-                                        const std::string& lang_tag,
+                                        const std::string& file_extension,
                                         const std::wstring& output_file);
 
     /// Asynchronously upload specific Crowdin file data.
     dispatch::future<void> UploadFile(const long project_id,
-                                      const long file_id,
                                       const Language& lang,
+                                      const long file_id,
+                                      const std::string& file_extension,
                                       const std::string& file_content);
 
 private:

--- a/src/crowdin_client.h
+++ b/src/crowdin_client.h
@@ -33,7 +33,6 @@
 #include "concurrency.h"
 #include "language.h"
 
-
 /**
     Client to the Crowdin platform.
  */
@@ -49,8 +48,8 @@ public:
     /// Is the user currently signed into Crowdin?
     bool IsSignedIn() const;
 
-    /// Wrap relative Crowdin link to absolute URL
-    static std::string WrapLink(const std::string& page);
+    static std::string GetOAuthBaseURL() { return "https://accounts.crowdin.com"; }
+    static std::string GetAboutURL() { return "https://crowdin.com"; }
 
     /**
         Authenticate with Crowdin.
@@ -133,6 +132,7 @@ private:
     class crowdin_http_client;
     std::unique_ptr<crowdin_http_client> m_api, m_oauth;
     std::shared_ptr<dispatch::promise<void>> m_authCallback;
+    std::string m_authStateRandomUUID;
 
     static CrowdinClient *ms_instance;
 };

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -548,7 +548,7 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
         return;
     }
 
-    std::cout << "Crowdin syncing file ..." << std::endl;
+    wxLogTrace("poedit.crowdin", "Crowdin syncing file ...");
 
     wxWindowPtr<CloudSyncProgressWindow> dlg(new CloudSyncProgressWindow(parent));
 
@@ -616,7 +616,7 @@ dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
 {
     const XLIFF1Catalog* xliff = dynamic_cast<const XLIFF1Catalog*>(file.get());
   
-    std::cout << "Uploading file: " << xliff->GetFileName() << std::endl;
+    wxLogTrace("Uploading file: %s", xliff->GetFileName().c_str());
     return CrowdinClient::Get().UploadFile(
                 xliff->GetCrowdinProjectId(), xliff->GetCrowdinFileId(), file->GetLanguage(),
                 file->SaveToBuffer()

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -375,7 +375,7 @@ private:
         {
             m_activity->Start();
             EnableAllChoices(false);
-            CrowdinClient::Get().GetProjectInfo(m_projects[sel-1].identifier)
+            CrowdinClient::Get().GetProjectInfo(m_projects[sel-1].id)
                 .then_on_window(this, &CrowdinOpenDialog::OnFetchedProjectInfo)
                 .catch_all(m_activity->HandleError);
         }
@@ -385,20 +385,13 @@ private:
     {
         m_info = prj;
         // Put supported files first in the list:
-        std::vector<std::wstring> f_unsup;
+        std::vector<CrowdinClient::FileInfo> f_unsup;
         m_info.files.clear();
         m_supportedFilesCount = 0;
         for (auto& i: prj.files)
         {
-            if (IsFileSupported(i))
-            {
-                m_info.files.push_back(i);
-                m_supportedFilesCount++;
-            }
-            else
-            {
-                f_unsup.push_back(i);
-            }
+            m_info.files.push_back(i);
+            m_supportedFilesCount++;
         }
         std::move(f_unsup.begin(), f_unsup.end(), std::inserter(m_info.files, m_info.files.end()));
 
@@ -411,15 +404,7 @@ private:
         m_file->Append("");
         for (auto& i: m_info.files)
         {
-            if (IsFileSupported(i))
-            {
-                m_file->Append(i);
-            }
-            else
-            {
-                /// TRANSLATORS: This is a file selector list, %s is filename, and it is shown for Crowdin files not editable in Poedit
-                m_file->Append(wxString::Format(L"%s — not supported", i));
-            }
+            m_file->Append(i.pathName);
         }
 
         EnableAllChoices();
@@ -476,17 +461,17 @@ private:
 
     void OnOK(wxCommandEvent&)
     {
-        auto crowdin_prj = m_info.identifier;
+        auto crowdin_prj = m_info.id;
         auto crowdin_file = m_info.files[m_file->GetSelection() - 1];
         auto crowdin_lang = m_info.languages[m_language->GetSelection() - 1];
         LanguageDialog::SetLastChosen(crowdin_lang);
-        OutLocalFilename = CreateLocalFilename(crowdin_file, crowdin_lang);
+        OutLocalFilename = CreateLocalFilename(crowdin_file.pathName, crowdin_lang);
 
         m_activity->Start(_(L"Downloading latest translations…"));
 
         auto outfile = std::make_shared<TempOutputFileFor>(OutLocalFilename);
         CrowdinClient::Get().DownloadFile(
-                crowdin_prj, crowdin_file, crowdin_lang,
+                crowdin_prj, crowdin_file.id, str::to_wstring(crowdin_lang.LanguageTag()),
                 outfile->FileName().ToStdWstring()
             )
             .then_on_window(this, [=]{
@@ -494,11 +479,6 @@ private:
                 AcceptAndClose();
             })
             .catch_all(m_activity->HandleError);
-    }
-
-    bool IsFileSupported(const wxString& name) const
-    {
-        return boost::ends_with(name, ".po") || boost::ends_with(name, ".pot");
     }
 
     wxString CreateLocalFilename(const wxString& name, const Language& lang)
@@ -520,9 +500,9 @@ private:
         if (!wxFileName::DirExists(cache))
             wxFileName::Mkdir(cache, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 
-        auto basename = name.AfterLast('/').BeforeLast('.');
+        auto basename = name.AfterLast('/');
 
-        return wxString::Format("%s%c%s_%s_%s.po", cache, wxFILE_SEP_PATH, m_info.name, basename, lang.Code());
+        return wxString::Format("%s%c%s_%s_%s.xliff", cache, wxFILE_SEP_PATH, m_info.name, lang.Code(), basename);
     }
 
 private:
@@ -573,6 +553,8 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
         return;
     }
 
+    std::cout << "Crowdin syncing file ..." << std::endl;
+
     const auto& header = catalog->Header();
     auto crowdin_prj = header.GetHeader("X-Crowdin-Project");
     auto crowdin_file = header.GetHeader("X-Crowdin-File");
@@ -601,7 +583,7 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
 
     // TODO: nicer API for this.
     // This must be done right after entering the modal loop (on non-OSX)
-    dlg->CallAfter([=]{
+    /*dlg->CallAfter([=]{
         CrowdinClient::Get().UploadFile(
                 str::to_utf8(crowdin_prj), str::to_wstring(crowdin_file), crowdin_lang,
                 catalog->SaveToBuffer()
@@ -631,7 +613,7 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
                     .catch_all(handle_error);
             })
             .catch_all(handle_error);
-    });
+    });ttt*/
 
     dlg->ShowWindowModal();
 }
@@ -646,6 +628,7 @@ dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
                         ? Language::TryParse(header.GetHeader("X-Crowdin-Language").ToStdWstring())
                         : file->GetLanguage();
 
+    std::cout << "Uploading file: " << crowdin_file << std::endl;
     return CrowdinClient::Get().UploadFile(
                 str::to_utf8(crowdin_prj), str::to_wstring(crowdin_file), crowdin_lang,
                 file->SaveToBuffer()

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -607,6 +607,10 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
     dlg->ShowWindowModal();
 }
 
+bool CrowdinSyncDestination::Auth(wxWindow* parent) {
+    return CrowdinClient::Get().IsSignedIn()
+            || CrowdinLoginDialog(parent).ShowModal() == wxID_OK;
+}
 
 dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
 {

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -481,7 +481,7 @@ private:
             + wxFILE_SEP_PATH + projectName
             + wxFILE_SEP_PATH + lang.Code()
             + wxFILE_SEP_PATH + crowdinFileName.GetPath() + wxFILE_SEP_PATH
-            << projectId << '_' << fileId << '_' << crowdinFileName.GetFullName();
+            + "CrowdinSync_" << projectId << '_' << fileId << '_' << crowdinFileName.GetFullName();
        
         if(localFileName.GetExt().CmpNoCase("po") != 0)// if not PO
             localFileName.SetFullName(localFileName.GetFullName() + ".xliff");

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -69,7 +69,7 @@ CrowdinLoginPanel::CrowdinLoginPanel(wxWindow *parent, int flags)
     sizer->AddSpacer(PX(10));
     auto logo = new wxStaticBitmap(this, wxID_ANY, wxArtProvider::GetBitmap("CrowdinLogoTemplate"));
     logo->SetCursor(wxCURSOR_HAND);
-    logo->Bind(wxEVT_LEFT_UP, [](wxMouseEvent&){ wxLaunchDefaultBrowser(CrowdinClient::WrapLink("/")); });
+    logo->Bind(wxEVT_LEFT_UP, [](wxMouseEvent&){ wxLaunchDefaultBrowser(CrowdinClient::GetAboutURL()); });
     sizer->Add(logo, wxSizerFlags().PXDoubleBorder(wxBOTTOM));
     auto explain = new ExplanationLabel(this, _("Crowdin is an online localization management platform and collaborative translation tool. Poedit can seamlessly sync PO files managed at Crowdin."));
     sizer->Add(explain, wxSizerFlags().Expand());
@@ -226,7 +226,7 @@ void CrowdinLoginPanel::OnSignOut(wxCommandEvent&)
 
 LearnAboutCrowdinLink::LearnAboutCrowdinLink(wxWindow *parent, const wxString& text)
     : LearnMoreLink(parent,
-                    CrowdinClient::WrapLink("/"),
+                    CrowdinClient::GetAboutURL(),
                     text.empty() ? (MSW_OR_OTHER(_("Learn more about Crowdin"), _("Learn More About Crowdin"))) : text)
 {
 }

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -482,10 +482,23 @@ private:
             + wxFILE_SEP_PATH + lang.Code()
             + wxFILE_SEP_PATH + crowdinFileName.GetPath() + wxFILE_SEP_PATH
             + "CrowdinSync_" << projectId << '_' << fileId << '_' << crowdinFileName.GetFullName();
-       
-        if(localFileName.GetExt().CmpNoCase("po") != 0)// if not PO
+
+        auto ext = localFileName.GetExt().Lower();
+        if (ext == "po")
+        {
+            // natively supported file format, will be opened as-is
+        }
+        else if (ext == "pot")
+        {
+            // POT files are natively supported, but need to be opened as PO to see translations
+            localFileName.SetFullName(localFileName.GetFullName() + ".po");
+        }
+        else
+        {
+            // Everything else is exported as XLIFF
             localFileName.SetFullName(localFileName.GetFullName() + ".xliff");
- 
+        }
+
         if (!wxFileName::DirExists(localFileName.GetPath()))
             wxFileName::Mkdir(localFileName.GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -385,17 +385,6 @@ private:
     void OnFetchedProjectInfo(CrowdinClient::ProjectInfo prj)
     {
         m_info = prj;
-        // Put supported files first in the list:
-        std::vector<CrowdinClient::FileInfo> f_unsup;
-        m_info.files.clear();
-        m_supportedFilesCount = 0;
-        for (auto& i: prj.files)
-        {
-            m_info.files.push_back(i);
-            m_supportedFilesCount++;
-        }
-        std::move(f_unsup.begin(), f_unsup.end(), std::inserter(m_info.files, m_info.files.end()));
-
         m_language->Clear();
         m_language->Append("");
         for (auto& i: m_info.languages)
@@ -431,10 +420,10 @@ private:
             }
         }
 
-        if (m_supportedFilesCount == 1)
+        if (m_info.files.size() == 1)
             m_file->SetSelection(1);
 
-        if (m_supportedFilesCount == 0)
+        if (m_info.files.size() == 0)
         {
             m_activity->StopWithError(_("This project has no files that can be translated in Poedit."));
             m_file->Disable();
@@ -445,7 +434,7 @@ private:
     void OnFileSelected()
     {
         auto filesel = m_file->GetSelection();
-        if (filesel - 1 < m_supportedFilesCount)
+        if (filesel - 1 < (int)m_info.files.size())
             m_activity->Stop();
         else
             m_activity->StopWithError(_(L"This file can only be edited in Crowdin’s web interface."));
@@ -457,7 +446,7 @@ private:
         e.Enable(!m_activity->IsRunning() &&
                  m_project->GetSelection() > 0 &&
                  m_language->GetSelection() > 0 &&
-                 filesel > 0 && filesel - 1 < m_supportedFilesCount);
+                 filesel > 0 && filesel - 1 < (int)m_info.files.size());
     }
 
     void OnOK(wxCommandEvent&)
@@ -510,7 +499,6 @@ private:
 
     std::vector<CrowdinClient::ProjectListing> m_projects;
     CrowdinClient::ProjectInfo m_info;
-    int m_supportedFilesCount;
 };
 
 } // anonymous namespace

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -483,7 +483,7 @@ private:
             + wxFILE_SEP_PATH + crowdinFileName.GetPath() + wxFILE_SEP_PATH
             << projectId << '_' << fileId << '_' << crowdinFileName.GetFullName();
        
-        if(localFileName.GetExt().CmpNoCase("po"))// if not PO
+        if(localFileName.GetExt().CmpNoCase("po") != 0)// if not PO
             localFileName.SetFullName(localFileName.GetFullName() + ".xliff");
  
         if (!wxFileName::DirExists(localFileName.GetPath()))
@@ -612,8 +612,8 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
                 dispatch::on_main([=]{
                     dlg->Activity->Start(_(L"Downloading latest translations…"));
                 });
-                if(filename.GetExt().CmpNoCase("po"))// if not PO
-                    filename.SetFullName(filename.GetName());// set original filename extension
+                if(filename.GetExt().CmpNoCase("po") != 0)// if not PO
+                    filename.SetFullName(filename.GetName());// set remote (Crowdin side) filename extension
                 return CrowdinClient::Get().DownloadFile(
                         catalog->GetCrowdinProjectId(),
                         crowdin_lang,

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -637,7 +637,7 @@ dispatch::future<void> CrowdinSyncDestination::Upload(CatalogPtr file)
                 file->GetCrowdinProjectId(),
                 crowdin_lang,
                 file->GetCrowdinFileId(),
-                std::string(wxFileName(file->GetFileName()).GetExt().Lower().utf8_str()),
+                std::string(wxFileName(file->GetFileName()).GetExt().utf8_str()),
                 file->SaveToBuffer()
             );
 }

--- a/src/crowdin_gui.h
+++ b/src/crowdin_gui.h
@@ -83,7 +83,7 @@ class CrowdinSyncDestination : public CloudSyncDestination
 {
 public:
     wxString GetName() const override { return "Crowdin"; }
-
+    bool Auth(wxWindow* parent) override;
     dispatch::future<void> Upload(CatalogPtr file) override;
 };
 

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1097,8 +1097,6 @@ void PoeditFrame::OnOpenFromCrowdin(wxCommandEvent&)
     DoIfCanDiscardCurrentDoc([=]{
         CrowdinOpenFile(this, [=](wxString name){
             DoOpenFile(name);
-            //if (m_catalog)
-            //    m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
         });
     });
 }
@@ -2716,12 +2714,20 @@ void PoeditFrame::WriteCatalog(const wxString& catalog, TFunctor completionHandl
     if (ManagerFrame::Get())
         ManagerFrame::Get()->NotifyFileChanged(GetFileName());
 
-    if (!m_syncing // avoid redundant upload during same call of OnUpdateFromCrowdin()=>
-                   // 1. =>DoIfCanDiscardCurrentDoc()=>Upload()
-                   // 2. =>CrowdinSyncFile()=>UploadFile()
-        && m_catalog->GetCloudSync())
-    {
-        CloudSyncProgressWindow::RunSync(this, m_catalog->GetCloudSync(), m_catalog);
+    if(!m_catalog->GetCloudSync()) {
+        if(m_catalog->IsFromCrowdin()) {
+            m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
+        }
+    }
+    
+    if (m_catalog->GetCloudSync()) {
+        // Avoid redundant upload during same call of 
+        // OnUpdateFromCrowdin()=>
+        // 1. =>DoIfCanDiscardCurrentDoc()=>Upload()
+        // 2. =>CrowdinSyncFile()=>UploadFile()
+        if(!m_syncing) {
+            CloudSyncProgressWindow::RunSync(this, m_catalog->GetCloudSync(), m_catalog);
+        }
     }
 
     if (tmUpdateThread.valid())

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -2714,21 +2714,17 @@ void PoeditFrame::WriteCatalog(const wxString& catalog, TFunctor completionHandl
     if (ManagerFrame::Get())
         ManagerFrame::Get()->NotifyFileChanged(GetFileName());
 
-    if(!m_catalog->GetCloudSync()) {
-        if(m_catalog->IsFromCrowdin()) {
+    if(!m_catalog->GetCloudSync())
+        if(m_catalog->IsFromCrowdin())
             m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
-        }
-    }
     
-    if (m_catalog->GetCloudSync()) {
+    if (m_catalog->GetCloudSync())
         // Avoid redundant upload during same call of 
         // OnUpdateFromCrowdin()=>
         // 1. =>DoIfCanDiscardCurrentDoc()=>Upload()
         // 2. =>CrowdinSyncFile()=>UploadFile()
-        if(!m_syncing) {
+        if(!m_syncing)
             CloudSyncProgressWindow::RunSync(this, m_catalog->GetCloudSync(), m_catalog);
-        }
-    }
 
     if (tmUpdateThread.valid())
         tmUpdateThread.wait();
@@ -2815,7 +2811,8 @@ void PoeditFrame::OnPurgeDeleted(wxCommandEvent& WXUNUSED(event))
     dlg->SetYesNoLabels(_("Purge"), _("Keep"));
 
     dlg->ShowWindowModalThenDo([this,dlg](int retcode){
-        if (retcode == wxID_YES) {
+        if (retcode == wxID_YES)
+        {
             m_catalog->RemoveDeletedItems();
             m_modified = true;
             UpdateTitle();

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -88,7 +88,6 @@
 #include "spellchecking.h"
 #include "str_helpers.h"
 
-
 namespace
 {
 

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -981,7 +981,7 @@ void PoeditFrame::DoIfCanDiscardCurrentDoc(TFunctor completionHandler, bool bSki
         // from event loop (and not this functions' caller) at an unspecified
         // time anyway, we can just as well defer it into the next idle time
         // iteration.
-        CallAfter([this,retval,completionHandler]() {
+        CallAfter([this,retval,completionHandler,bSkipUpload]() {
 #endif
 
         if (retval == wxID_YES)

--- a/src/edframe.h
+++ b/src/edframe.h
@@ -379,6 +379,7 @@ private:
         bool m_hasObsoleteItems;
         bool m_displayIDs;
         bool m_setSashPositionsWhenMaximized;
+        bool m_syncing = false;
 };
 
 

--- a/src/edframe.h
+++ b/src/edframe.h
@@ -116,7 +116,7 @@ class PoeditFrame : public PoeditFrameBase
         void WriteCatalog(const wxString& catalog);
 
         template<typename TFunctor>
-        void WriteCatalog(const wxString& catalog, TFunctor completionHandler);
+        void WriteCatalog(const wxString& catalog, TFunctor completionHandler, bool bSkipUpload = false);
 
         void FixDuplicatesIfPresent();
         void WarnAboutLanguageIssues();
@@ -203,7 +203,7 @@ class PoeditFrame : public PoeditFrameBase
         // if there's modified catalog, ask user to save it; return true
         // if it's save to discard m_catalog and load new data
         template<typename TFunctor>
-        void DoIfCanDiscardCurrentDoc(TFunctor completionHandler);
+        void DoIfCanDiscardCurrentDoc(TFunctor completionHandler, bool bSkipUpload = false);
         bool NeedsToAskIfCanDiscardCurrentDoc() const;
         wxWindowPtr<wxMessageDialog> CreateAskAboutSavingDialog();
 
@@ -379,7 +379,6 @@ private:
         bool m_hasObsoleteItems;
         bool m_displayIDs;
         bool m_setSashPositionsWhenMaximized;
-        bool m_syncing = false;
 };
 
 

--- a/src/gexecute.cpp
+++ b/src/gexecute.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include <wx/defs.h>
 #include <wx/utils.h>
 #include <wx/log.h>
 #include <wx/process.h>

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -34,7 +34,6 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
-
 multipart_form_data::multipart_form_data()
 {
     boost::uuids::random_generator gen;

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -34,6 +34,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
+
 multipart_form_data::multipart_form_data()
 {
     boost::uuids::random_generator gen;

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -52,6 +52,20 @@ public:
     virtual std::string body() const = 0;
 };
 
+class octet_stream_data : public http_body_data
+{
+public:
+    octet_stream_data(const std::string& body) : m_body(body) {};
+
+    /// Content-Type header to use with the data.
+    std::string content_type() const override { return "application/octet-stream"; };
+
+    /// Returns generated body of the request.
+    std::string body() const override { return m_body; };
+private:
+    std::string m_body;
+};
+
 /// Stores POSTed data (RFC 1867)
 class multipart_form_data : public http_body_data
 {
@@ -113,6 +127,8 @@ public:
         default_flags = 0
     };
 
+    using headers = std::vector<std::pair<std::string, std::string>>;
+
     /**
         Creates an instance of the client object.
         
@@ -148,7 +164,7 @@ public:
     /**
         Perform a POST request with multipart/form-data formatted @a params.
      */
-    dispatch::future<json> post(const std::string& url, const http_body_data& data);
+    dispatch::future<json> post(const std::string& url, const http_body_data& data, const headers& hdrs = headers());
 
 
     // Helper for encoding text as URL-encoded UTF-8

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -228,9 +228,19 @@ public:
         });
     }
 
-    dispatch::future<::json> post(const std::string& url, const http_body_data& data)
+    dispatch::future<::json> post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
     {
         http::http_request req(http::methods::POST);
+        for(const auto& h : hdrs) {
+            req.headers().add(
+                // Take care about conversion from std::string in case of
+                // std::wstring used in headers as well what is default
+                // for _WIN32 in cpprest for some reason
+                // (it's safe since we expect only ANSI in header names)
+                utility::string_t(h.first.begin(), h.first.end()),
+                utility::string_t(h.second.begin(), h.second.end())
+            );
+        }
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())
@@ -354,7 +364,7 @@ dispatch::future<void> http_client::download(const std::string& url, const std::
     return m_impl->download(url, output_file);
 }
 
-dispatch::future<::json> http_client::post(const std::string& url, const http_body_data& data)
+dispatch::future<::json> http_client::post(const std::string& url, const http_body_data& data, const headers& hdrs)
 {
-    return m_impl->post(url, data);
+    return m_impl->post(url, data, hdrs);
 }

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -199,7 +199,7 @@ public:
 
     dispatch::future<void> download(const std::string& url, const std::wstring& output_file)
     {
-        std::cout << "\n\nDowloading file: " << url << "\n\n";
+        wxLogTrace("poedit.http_client", "Dowloading file: %s", url.c_str());
         using namespace concurrency::streams;
         auto fileStream = std::make_shared<ostream>();
 
@@ -217,13 +217,13 @@ public:
         })
         .then([=](http::http_response response)
         {
-            std::cout << "\n\nDownloading file response: "<<response.status_code()<<", "<<response.headers().content_type()<<"\n\n";
+            wxLogTrace("poedit.http_client", "Downloading file response: %hu, %s", response.status_code(), response.headers().content_type().c_str());
             handle_error(response);
             return response.body().read_to_end(fileStream->streambuf());
         })
         .then([=](size_t)
         {
-            std::cout << "\n\nDownloading file: closing\n\n";
+            wxLogTrace("poedit.http_client", "Downloading file: closing");
             return fileStream->close();
         });
     }

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -182,7 +182,11 @@ public:
     dispatch::future<::json> get(const std::string& url)
     {
         http::http_request req(http::methods::GET);
-        req.headers().add(http::header_names::accept,     L"application/json");
+        //TODO: figure out why Crowdin API v2 GET method (at least `/user`)
+        //      returns below errors unless below line commented
+        //      HTTP error: 400 Bad Request
+        //      JSON error: Incorrect Accept Header. 'application/json' expected
+        //req.headers().add(http::header_names::accept,     L"application/json");
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -231,7 +231,7 @@ public:
     dispatch::future<::json> post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
     {
         http::http_request req(http::methods::POST);
-        for(const auto& h : hdrs) {
+        for(const auto& h : hdrs)
             req.headers().add(
                 // Take care about conversion from std::string in case of
                 // std::wstring used in headers as well what is default
@@ -240,7 +240,6 @@ public:
                 utility::string_t(h.first.begin(), h.first.end()),
                 utility::string_t(h.second.begin(), h.second.end())
             );
-        }
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -182,11 +182,6 @@ public:
     dispatch::future<::json> get(const std::string& url)
     {
         http::http_request req(http::methods::GET);
-        //TODO: figure out why Crowdin API v2 GET method (at least `/user`)
-        //      returns below errors unless below line commented
-        //      HTTP error: 400 Bad Request
-        //      JSON error: Incorrect Accept Header. 'application/json' expected
-        //req.headers().add(http::header_names::accept,     L"application/json");
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())
@@ -204,6 +199,7 @@ public:
 
     dispatch::future<void> download(const std::string& url, const std::wstring& output_file)
     {
+        std::cout << "\n\nDowloading file: " << url << "\n\n";
         using namespace concurrency::streams;
         auto fileStream = std::make_shared<ostream>();
 
@@ -221,11 +217,13 @@ public:
         })
         .then([=](http::http_response response)
         {
+            std::cout << "\n\nDownloading file response: "<<response.status_code()<<", "<<response.headers().content_type()<<"\n\n";
             handle_error(response);
             return response.body().read_to_end(fileStream->streambuf());
         })
         .then([=](size_t)
         {
+            std::cout << "\n\nDownloading file: closing\n\n";
             return fileStream->close();
         });
     }
@@ -233,7 +231,6 @@ public:
     dispatch::future<::json> post(const std::string& url, const http_body_data& data)
     {
         http::http_request req(http::methods::POST);
-        req.headers().add(http::header_names::accept,     L"application/json");
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -182,6 +182,12 @@ public:
     dispatch::future<::json> get(const std::string& url)
     {
         http::http_request req(http::methods::GET);
+        // For some very strange reason if to uncomment below line (i.e. to add "Accept: application/json" header)
+        // then GET /user API request in CrowdinClient::GetUserInfo() causes
+        // 406 "Incorrect Accept Header. 'application/json' expected" error response raised to CrowdinClient::on_error_response()
+        // And this happens only on Linux even with latest https://github.com/microsoft/cpprestsdk/commit/7fbb08c491f9c8888cc0f3d86962acb3af672772 (as of writting this comment)
+        // While no problem on Windows and Mac
+        // req.headers().add(http::header_names::accept, L"application/json");
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);
         if (!m_auth.empty())
@@ -231,6 +237,8 @@ public:
     dispatch::future<::json> post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
     {
         http::http_request req(http::methods::POST);
+        // Same reason of commenting below line as in http_client::impl::get() above
+        // req.headers().add(http::header_names::accept, L"application/json");
         for(const auto& h : hdrs)
             req.headers().add(
                 to_string_t(h.first),

--- a/src/http_client_casablanca.cpp
+++ b/src/http_client_casablanca.cpp
@@ -233,12 +233,8 @@ public:
         http::http_request req(http::methods::POST);
         for(const auto& h : hdrs)
             req.headers().add(
-                // Take care about conversion from std::string in case of
-                // std::wstring used in headers as well what is default
-                // for _WIN32 in cpprest for some reason
-                // (it's safe since we expect only ANSI in header names)
-                utility::string_t(h.first.begin(), h.first.end()),
-                utility::string_t(h.second.begin(), h.second.end())
+                to_string_t(h.first),
+                to_string_t(h.second)
             );
         req.headers().add(http::header_names::user_agent, m_userAgent);
         req.headers().add(http::header_names::accept_language, ui_language);

--- a/src/http_client_macos.mm
+++ b/src/http_client_macos.mm
@@ -147,9 +147,8 @@ public:
                                                               path:str::to_NS(url)
                                                         parameters:nil];
     
-        for(const auto& h : hdrs) {
+        for(const auto& h : hdrs)
             [request addValue:str::to_NS(h.second) forHTTPHeaderField:str::to_NS(h.first)];
-        }
 
         auto body = data.body();
         [request setValue:str::to_NS(data.content_type()) forHTTPHeaderField:@"Content-Type"];

--- a/src/http_client_macos.mm
+++ b/src/http_client_macos.mm
@@ -139,13 +139,17 @@ public:
         return promise->get_future();
     }
 
-    dispatch::future<json> post(const std::string& url, const http_body_data& data)
+    dispatch::future<json> post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
     {
         auto promise = std::make_shared<dispatch::promise<json>>();
 
         NSMutableURLRequest *request = [m_native requestWithMethod:@"POST"
                                                               path:str::to_NS(url)
                                                         parameters:nil];
+    
+        for(const auto& h : hdrs) {
+            [request addValue:str::to_NS(h.second) forHTTPHeaderField:str::to_NS(h.first)];
+        }
 
         auto body = data.body();
         [request setValue:str::to_NS(data.content_type()) forHTTPHeaderField:@"Content-Type"];
@@ -250,7 +254,7 @@ dispatch::future<void> http_client::download(const std::string& url, const std::
     return m_impl->download(url, output_file);
 }
 
-dispatch::future<json> http_client::post(const std::string& url, const http_body_data& data)
+dispatch::future<json> http_client::post(const std::string& url, const http_body_data& data, const http_client::headers& hdrs)
 {
-    return m_impl->post(url, data);
+    return m_impl->post(url, data, hdrs);
 }


### PR DESCRIPTION
Added support (from customer's prospective):
- [Crowdin for enterprise](https://crowdin.com/enterprise)
  - Works with Crowdin Enterprise accounts of any organization (on any domains)
- Open/save/sync as Xliff any file which can be parsed for translations by Crowdin 
- While continue to work with PO natively as is

Improved
- Path to locally stored Crowdin files contains `<project name>/<lang code>/<branch><path to file in Crowdin project>`
- Files opened via `Open from Crowdin` can be saved/synced back to Crowdin on further open and edit as local file from file system (simplest from `File` menu's Recent list/history)

Migrated to new:
- OAuth improved/updated that works with API v2
- API v2

#### This PR is clean version of #629 with
- Work with PO natively (as is without converting to/from Xliff) is back
- Clean/arranged/grouped commits
- Back to implicit flows with few improvements
  - `state` param passed to OAuth URL and checked when callback received
  - OAuth URL redirect via poedit.net replaced with direct to Crowdin OAuth URL but source tracking params added (to identify authentication via Poedit for statistics)