### PR TITLE
Crowdin v2 saving consistency

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -53,7 +53,6 @@
 
 #include <set>
 #include <algorithm>
-#include <regex>
 
 
 // ----------------------------------------------------------------------
@@ -606,33 +605,6 @@ void Catalog::SetFileName(const wxString& fn)
     m_fileName = f.GetFullPath();
 }
 
-bool Catalog::IsFromCrowdin() const
-{
-    if (m_crowdinFileId > 0 && m_crowdinProjectId > 0)
-        return true;
-
-    if (m_header.HasHeader("X-Crowdin-Project-ID") && m_header.HasHeader("X-Crowdin-File-ID"))
-    {
-        if (!(m_crowdinFileId > 0 && m_crowdinProjectId > 0))
-        {
-            m_crowdinProjectId = std::stoi(m_header.GetHeader("X-Crowdin-Project-ID").ToStdString());
-            m_crowdinFileId = std::stoi(m_header.GetHeader("X-Crowdin-File-ID").ToStdString());
-        }
-        return true;
-    }
-    static const std::wregex RE_CROWDIN_FILE(L"^Crowdin\\.([0-9]+)\\.([0-9]+) .*");
-    auto name = wxFileName(m_fileName).GetName().ToStdWstring();
-
-    std::wsmatch m;
-    if (regex_match(name, m, RE_CROWDIN_FILE))
-    {
-        m_crowdinProjectId = std::stoi(m.str(1));
-        m_crowdinFileId = std::stoi(m.str(2));
-        return m_crowdinFileId > 0 && m_crowdinProjectId > 0;
-    }
-
-    return false;
-}
 
 namespace
 {

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -550,13 +550,6 @@ class Catalog
 
         /// Change the catalog's language and update headers accordingly
         virtual void SetLanguage(Language lang);
-
-        /// Is the PO file from Crowdin, i.e. sync-able?
-        bool IsFromCrowdin() const;
-        // FIXME: This shouldn't be here
-        int GetCrowdinFileId() const { return m_crowdinFileId; }
-        int GetCrowdinProjectId() const { return m_crowdinProjectId; }
-        void SetCrowdinProjectAndFileId(int projId, int fileId) { m_crowdinProjectId  = projId; m_crowdinFileId = fileId; }
             
         /// Returns true if the catalog contains obsolete entries (~.*)
         virtual bool HasDeletedItems() const = 0;
@@ -597,7 +590,6 @@ class Catalog
         bool m_isOk;
         Type m_fileType;
         wxString m_fileName;
-        mutable int m_crowdinFileId = -1, m_crowdinProjectId = -1;
         HeaderData m_header;
         Language m_sourceLanguage;
 

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -250,6 +250,12 @@ LearnAboutCrowdinLink::LearnAboutCrowdinLink(wxWindow *parent, const wxString& t
 namespace
 {
 
+inline wxString GetCrowdinCacheDir()
+{
+    return CloudSyncDestination::GetCacheDir() + "/Crowdin/";
+}
+
+
 class CrowdinLoginDialog : public wxDialog
 {
 public:
@@ -616,7 +622,7 @@ private:
         std::replace_if(fileName.begin(), fileName.end(), boost::is_any_of("\\/:\"<>|?*"), '_');
         std::replace_if(projectName.begin(), projectName.end(), boost::is_any_of("\\/:\"<>|?*"), '_');
 
-        const wxString dir = CloudSyncDestination::GetCacheDir() + "/Crowdin/" + projectName + " - " + lang.Code();
+        const wxString dir = GetCrowdinCacheDir() + projectName + " - " + lang.Code();
         wxFileName localFileName(dir + "/Crowdin." << projectId << '.' << fileId << ' ' << fileName);
 
         auto ext = localFileName.GetExt().Lower();
@@ -701,6 +707,12 @@ bool ExtractCrowdinMetadata(CatalogPtr cat,
 bool CanSyncWithCrowdin(CatalogPtr cat)
 {
     return ExtractCrowdinMetadata(cat, nullptr);
+}
+
+
+bool ShouldSyncToCrowdinAutomatically(CatalogPtr cat)
+{
+    return cat->GetFileName().StartsWith(GetCrowdinCacheDir());
 }
 
 

--- a/src/crowdin_gui.h
+++ b/src/crowdin_gui.h
@@ -97,6 +97,9 @@ public:
 };
 
 
+/// Can given file by synced to Crowdin, i.e. does it come from Crowdin and does it have required metadata?
+bool CanSyncWithCrowdin(CatalogPtr cat);
+
 /**
     Let the user choose a Crowdin file, download it and open in Poedit.
     

--- a/src/crowdin_gui.h
+++ b/src/crowdin_gui.h
@@ -100,6 +100,9 @@ public:
 /// Can given file by synced to Crowdin, i.e. does it come from Crowdin and does it have required metadata?
 bool CanSyncWithCrowdin(CatalogPtr cat);
 
+/// Was the file opened directly from Crowdin and should be synced when the user saves it?
+bool ShouldSyncToCrowdinAutomatically(CatalogPtr cat);
+
 /**
     Let the user choose a Crowdin file, download it and open in Poedit.
     

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1777,8 +1777,8 @@ void PoeditFrame::OnUpdateFromSources(wxCommandEvent&)
 void PoeditFrame::OnUpdateFromSourcesUpdate(wxUpdateUIEvent& event)
 {
     event.Enable(m_catalog &&
-                 !m_catalog->IsFromCrowdin() &&
-                 m_catalog->HasSourcesConfigured());
+                 m_catalog->HasSourcesConfigured() &&
+                 !CanSyncWithCrowdin(m_catalog));
 }
 
 void PoeditFrame::OnUpdateFromPOT(wxCommandEvent&)
@@ -1852,8 +1852,9 @@ void PoeditFrame::OnUpdateFromCrowdin(wxCommandEvent&)
 
 void PoeditFrame::OnUpdateFromCrowdinUpdate(wxUpdateUIEvent& event)
 {
-    event.Enable(m_catalog && m_catalog->IsFromCrowdin() &&
-                 m_catalog->HasCapability(Catalog::Cap::Translations));
+    event.Enable(m_catalog &&
+                 m_catalog->HasCapability(Catalog::Cap::Translations) &&
+                 CanSyncWithCrowdin(m_catalog));
 }
 #endif
 
@@ -1862,7 +1863,7 @@ void PoeditFrame::OnUpdateSmart(wxCommandEvent& event)
     if (!m_catalog)
         return;
 #ifdef HAVE_HTTP_CLIENT
-    if (m_catalog->IsFromCrowdin())
+    if (CanSyncWithCrowdin(m_catalog))
         OnUpdateFromCrowdin(event);
     else
 #endif
@@ -1875,7 +1876,7 @@ void PoeditFrame::OnUpdateSmartUpdate(wxUpdateUIEvent& event)
     if (m_catalog)
     {
 #ifdef HAVE_HTTP_CLIENT
-       if (m_catalog->IsFromCrowdin())
+       if (CanSyncWithCrowdin(m_catalog))
             OnUpdateFromCrowdinUpdate(event);
         else
 #endif
@@ -2378,7 +2379,7 @@ void PoeditFrame::ReadCatalog(const CatalogPtr& cat)
     // Can't do this with the window being frozen, because positioning the toolbar
     // in presence of mCtrl menubar would not size & repaint properly:
 #ifdef HAVE_HTTP_CLIENT
-    m_toolbar->EnableSyncWithCrowdin(m_catalog->IsFromCrowdin());
+    m_toolbar->EnableSyncWithCrowdin(CanSyncWithCrowdin(m_catalog));
 #endif
 
     FixDuplicatesIfPresent();
@@ -2504,7 +2505,7 @@ void PoeditFrame::WarnAboutLanguageIssues()
         }
         else // no error, check for warning-worthy stuff
         {
-            if (lang.IsValid() && plForms != lang.DefaultPluralFormsExpr() && !m_catalog->IsFromCrowdin())
+            if (lang.IsValid() && plForms != lang.DefaultPluralFormsExpr() && !CanSyncWithCrowdin(m_catalog))
             {
                 AttentionMessage msg
                     (

--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1174,8 +1174,6 @@ void PoeditFrame::OnOpenFromCrowdin(wxCommandEvent&)
     DoIfCanDiscardCurrentDoc([=]{
         CrowdinOpenFile(this, [=](wxString name){
             DoOpenFile(name);
-            if (m_catalog)
-                m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
         });
     });
 }
@@ -2379,6 +2377,12 @@ void PoeditFrame::ReadCatalog(const CatalogPtr& cat)
     // Can't do this with the window being frozen, because positioning the toolbar
     // in presence of mCtrl menubar would not size & repaint properly:
 #ifdef HAVE_HTTP_CLIENT
+    if (!m_catalog->GetCloudSync())
+    {
+        if (ShouldSyncToCrowdinAutomatically(m_catalog))
+            m_catalog->AttachCloudSync(std::make_shared<CrowdinSyncDestination>());
+    }
+
     m_toolbar->EnableSyncWithCrowdin(CanSyncWithCrowdin(m_catalog));
 #endif
 


### PR DESCRIPTION
Addresses #638, #641 discussions:

1. Files fetched from Crowdin in-app, or fetched previously and now opened from recent files, are synced when saved
2. The explicit Sync button always saves first, avoiding double-upload and any funny asynchronous business