### PR TITLE
Sync XLIFF downloaded from Crowdin UI in browser

### DIFF
--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -460,7 +460,7 @@ Catalog::ValidationResults XLIFFCatalog::Validate(bool)
     return res;
 }
 
-const char* XLIFFCatalog::GetXPathValue(const char* xpath) const
+std::string XLIFFCatalog::GetXPathValue(const char* xpath) const
 {
     auto x = m_doc.child("xliff").select_node(xpath);
     auto v = x.attribute().value();

--- a/src/catalog_xliff.cpp
+++ b/src/catalog_xliff.cpp
@@ -460,7 +460,17 @@ Catalog::ValidationResults XLIFFCatalog::Validate(bool)
     return res;
 }
 
-
+const char* XLIFFCatalog::GetXPathValue(const char* xpath) const
+{
+    auto x = m_doc.child("xliff").select_node(xpath);
+    auto v = x.attribute().value();
+    if (v)
+        return v;
+     v = x.node().value();
+     if (v)
+         return v;
+     return "";
+}
 
 
 

--- a/src/catalog_xliff.h
+++ b/src/catalog_xliff.h
@@ -109,6 +109,7 @@ public:
     void RemoveDeletedItems() override {}
 
     pugi::xml_node GetXMLRoot() const { return m_doc.child("xliff"); }
+    const char* GetXPathValue(const char* xpath) const;
 
 protected:
     XLIFFCatalog(const wxString& filename, pugi::xml_document&& doc)

--- a/src/catalog_xliff.h
+++ b/src/catalog_xliff.h
@@ -109,7 +109,7 @@ public:
     void RemoveDeletedItems() override {}
 
     pugi::xml_node GetXMLRoot() const { return m_doc.child("xliff"); }
-    const char* GetXPathValue(const char* xpath) const;
+    std::string GetXPathValue(const char* xpath) const;
 
 protected:
     XLIFFCatalog(const wxString& filename, pugi::xml_document&& doc)

--- a/src/crowdin_client.cpp
+++ b/src/crowdin_client.cpp
@@ -424,8 +424,8 @@ dispatch::future<void> CrowdinClient::DownloadFile(int project_id,
 
     wxString ext(file_extension);
     ext.MakeLower();
-    const bool isXLIFFNative = (ext == "xliff" || ext == "xlf");
-    const bool isXLIFFConverted = (!isXLIFFNative && ext != "po" && ext != "pot");
+
+    const bool isXLIFFConverted = (ext != "po" && ext != "pot");
 
     return m_api->post(
         "projects/" + std::to_string(project_id) + "/translations/builds/files/" + std::to_string(file_id),
@@ -445,7 +445,7 @@ dispatch::future<void> CrowdinClient::DownloadFile(int project_id,
             wxString outfile(output_file);
             file.move_to(outfile);
 
-            if (isXLIFFNative || isXLIFFConverted)
+            if (isXLIFFConverted)
                 PostprocessDownloadedXLIFF(outfile);
         });
 }

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -677,25 +677,16 @@ bool ExtractCrowdinMetadata(CatalogPtr cat,
                 : cat->GetLanguage();
     }
 
-    if (const auto xliff = dynamic_cast<XLIFFCatalog*>(cat.get()))
+    const auto xliff = std::dynamic_pointer_cast<XLIFFCatalog>(cat);
+    if (xliff)
     {
-        auto xml = xliff->GetXMLRoot();
-        int projId = xml.attribute("project-id").as_int(-1);
-        if (projId > 0)
+        if (std::strcmp(xliff->GetXPathValue("file/header/tool//@tool-id"), "crowdin") == 0)
         {
-            auto files = xml.children("file");
-            if (files.begin() != files.end())
-            {
-                int _fileId = files.begin()->attribute("id").as_int(-1);
-                if (_fileId > 0)
-                {
-                    if (projectId)
-                        *projectId = projId;
-                    if (fileId)
-                        *fileId = _fileId;
-                    return true;
-                }
-            }
+            if (projectId)
+                *projectId = std::stoi(xliff->GetXPathValue("file//@project-id"));
+            if (fileId)
+                *fileId = std::stoi(xliff->GetXPathValue("file//@id"));
+            return true;
         }
     }
     

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -39,6 +39,7 @@
 #include "languagectrl.h"
 #include "str_helpers.h"
 #include "utility.h"
+#include "catalog_xliff.h"
 
 #include <wx/app.h>
 #include <wx/artprov.h>
@@ -676,6 +677,28 @@ bool ExtractCrowdinMetadata(CatalogPtr cat,
                 : cat->GetLanguage();
     }
 
+    if (const auto xliff = dynamic_cast<XLIFFCatalog*>(cat.get()))
+    {
+        auto xml = xliff->GetXMLRoot();
+        int projId = xml.attribute("project-id").as_int(-1);
+        if (projId > 0)
+        {
+            auto files = xml.children("file");
+            if (files.begin() != files.end())
+            {
+                int _fileId = files.begin()->attribute("id").as_int(-1);
+                if (_fileId > 0)
+                {
+                    if (projectId)
+                        *projectId = projId;
+                    if (fileId)
+                        *fileId = _fileId;
+                    return true;
+                }
+            }
+        }
+    }
+    
     if (hdr.HasHeader("X-Crowdin-Project-ID") && hdr.HasHeader("X-Crowdin-File-ID"))
     {
         if (projectId)

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -682,10 +682,10 @@ bool ExtractCrowdinMetadata(CatalogPtr cat,
     {
         if (std::strcmp(xliff->GetXPathValue("file/header/tool//@tool-id"), "crowdin") == 0)
         {
-            if (projectId)
-                *projectId = std::stoi(xliff->GetXPathValue("file//@project-id"));
+            if (projectId) 
+                *projectId = std::atoi(xliff->GetXPathValue("file/@*[local-name()='project-id']"));
             if (fileId)
-                *fileId = std::stoi(xliff->GetXPathValue("file//@id"));
+                *fileId = std::atoi(xliff->GetXPathValue("file/@*[local-name()='id']"));
             return true;
         }
     }

--- a/src/crowdin_gui.cpp
+++ b/src/crowdin_gui.cpp
@@ -666,7 +666,7 @@ private:
 
 bool ExtractCrowdinMetadata(CatalogPtr cat,
                             Language *lang = nullptr,
-                            int *projectId = nullptr, int *fileId = nullptr, std::string* xliffRemoteFilename = nullptr)
+                            int *projectId = nullptr, int *fileId = nullptr)
 {
     auto& hdr = cat->Header();
 
@@ -688,8 +688,6 @@ bool ExtractCrowdinMetadata(CatalogPtr cat,
                     *projectId = std::stoi(xliff->GetXPathValue("file/@*[local-name()='project-id']"));
                 if (fileId)
                     *fileId = std::stoi(xliff->GetXPathValue("file/@*[local-name()='id']"));
-                if (xliffRemoteFilename)
-                    *xliffRemoteFilename = xliff->GetXPathValue("file/@*[local-name()='original']");
                 return true;
             }
             catch (...)
@@ -780,8 +778,7 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
 
     Language crowdinLang;
     int projectId, fileId;
-    std::string xliffRemoteFilename;
-    ExtractCrowdinMetadata(catalog, &crowdinLang, &projectId, &fileId, &xliffRemoteFilename);
+    ExtractCrowdinMetadata(catalog, &crowdinLang, &projectId, &fileId);
 
     auto handle_error = [=](dispatch::exception_ptr e){
         dispatch::on_main([=]{
@@ -819,14 +816,6 @@ void CrowdinSyncFile(wxWindow *parent, std::shared_ptr<Catalog> catalog,
                 dispatch::on_main([=]{
                     dlg->Activity->Start(_(L"Downloading latest translations…"));
                 });
-
-                if (xliffRemoteFilename.empty())
-                {
-                    if (filename.GetExt().CmpNoCase("po") != 0)  // if not PO
-                        filename.SetFullName(filename.GetName());  // set remote (Crowdin side) filename extension
-                }
-                else
-                    filename = xliffRemoteFilename;
 
                 return CrowdinClient::Get().DownloadFile(
                         projectId,


### PR DESCRIPTION
By project and file ID stored in XLIFF attributes.
Just like for PO it implemented earlier

Since Crowdin team confirmed that already added `project-id` attribute to `xliff` xml node thought they need few days to make it available/released in their app/service publically/production. But I've decided to implement this useful feature in advance to get it chance to be included in v2.4 Poedit release. So I've tested to confirm it work in Poedit right now by just adding `project-id="12334"` (where `1234` replaced with real project numeric ID) to `xliff` attribute manually