### PR TITLE
Compilation fix for !HAVE_HTTP_CLIENT in 2.4

### DIFF
--- a/src/edframe.cpp
+++ b/src/edframe.cpp
@@ -1775,9 +1775,14 @@ void PoeditFrame::OnUpdateFromSources(wxCommandEvent&)
 
 void PoeditFrame::OnUpdateFromSourcesUpdate(wxUpdateUIEvent& event)
 {
+#if HAVE_HTTP_CLIENT
     event.Enable(m_catalog &&
                  m_catalog->HasSourcesConfigured() &&
                  !CanSyncWithCrowdin(m_catalog));
+#else
+    event.Enable(m_catalog &&
+                 m_catalog->HasSourcesConfigured());
+#endif
 }
 
 void PoeditFrame::OnUpdateFromPOT(wxCommandEvent&)
@@ -2539,8 +2544,13 @@ void PoeditFrame::WarnAboutLanguageIssues()
         }
         else // no error, check for warning-worthy stuff
         {
-            if (lang.IsValid() && plForms != lang.DefaultPluralFormsExpr() && !CanSyncWithCrowdin(m_catalog))
+            if (lang.IsValid() && plForms != lang.DefaultPluralFormsExpr())
             {
+#ifdef HAVE_HTTP_CLIENT
+                if (!CanSyncWithCrowdin(m_catalog))
+                    return;
+#endif
+
                 AttentionMessage msg
                     (
                         "unusual-plural-forms",


### PR DESCRIPTION
Hello,

This pr wraps two call to `CanSyncWithCrowdin` inside an `#ifdef HAVE_HTTP_CLIENT`.  That functions is not available if the http client is disabled, so it wouldn't compile.  Noticed while I was updating the OpenBSD port, since there the http client is disabled (C++ rest is not yet available as package).

Lightly tested, as I'm not sure how to exactly trigger that codepath, but it shouldn't introduce regressions.

Thanks for developing this, keep up the good work :)