### PR TITLE
Add missing include

### DIFF
--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -67,6 +67,7 @@
     #endif
 #endif
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 


### PR DESCRIPTION
Fix ' concurrency.h:606:10: error: ‘atomic_bool’ in namespace ‘std’ does not name a type; did you mean ‘atomic_load’? ' build error.