### PR TITLE
Fixed linker error on OSX 11.1 (Big Sur)

### DIFF
--- a/deps/build.ninja
+++ b/deps/build.ninja
@@ -337,6 +337,24 @@ rule gettext_build
       rm -f $$tmp $
       && echo $
       'note: ⋯  $
+      $top_srcdir/../macos/fixup-dylib-deps.sh $
+      /lib @rpath $
+      $destdir/lib $
+      $destdir/bin/*' $
+      && $
+      tmp=`mktemp` $
+      && $
+      $top_srcdir/../macos/fixup-dylib-deps.sh $
+      /lib @rpath $
+      $destdir/lib $
+      $destdir/bin/* $
+      >$$tmp 2>&1 $
+      || (cat $
+      $$tmp ; $
+      exit 1) && $
+      rm -f $$tmp $
+      && echo $
+      'note: ⋯  $
       strip -S -u $
       -r $
       $destdir/bin/{msgfmt,msgmerge,msgunfmt,msgcat,xgettext}' $

--- a/deps/build_deps.sh
+++ b/deps/build_deps.sh
@@ -12,6 +12,9 @@ fi
 # Include Homebrew binaries on PATH if not there yet:
 PATH="$PATH:/usr/local/bin"
 
+# Include Macports binaries on PATH if not there yet:
+PATH="$PATH:/opt/local/bin"
+
 # Fake Java binaries so that gettext configure script doesn't invoke the system ones:
 mkdir -p "$DEPS_BUILD_DIR/helpers"
 touch "$DEPS_BUILD_DIR"/helpers/{java,javac}

--- a/deps/generate_build_ninja.py
+++ b/deps/generate_build_ninja.py
@@ -162,6 +162,7 @@ with open('build.ninja', 'w') as buildfile:
                                      'rm -f $destdir/bin/{autopoint,envsubst,gettext*,ngettext,recode-sr-latin}',
                                      # fix dylib references to work
                                      '$top_srcdir/../macos/fixup-dylib-deps.sh //lib @executable_path/../lib $destdir/lib $destdir/bin/*',
+                                     '$top_srcdir/../macos/fixup-dylib-deps.sh /lib @rpath $destdir/lib $destdir/bin/*',
                                      # strip executables
                                      'strip -S -u -r $destdir/bin/{msgfmt,msgmerge,msgunfmt,msgcat,xgettext}',
                                      'strip -S -x $destdir/lib/lib*.*.dylib',


### PR DESCRIPTION
Building the master branch on Mac OSX 11.1 (Big Sur) currently fails due to a wrong library path in the gettext binaries:

![Bildschirmfoto 2020-12-20 um 12 54 13](https://user-images.githubusercontent.com/219138/102712579-940e8400-42c2-11eb-8e48-4600fef0ff8d.png)

I added another call to fixup-dylib-deps.sh in generate_build_ninja.py to change the path from **/lib** to **@rpath** which fixed the problem on my machine.

I also added the Macports binary path to deps/build_deps.sh to support people using only macports (not homebrew).

Please note that Poedit still fails whith a segfault when I run it after the build, but this is a different issue.
