### PR TITLE
Escape '&' in the comment sidebar

### DIFF
--- a/src/customcontrols.cpp
+++ b/src/customcontrols.cpp
@@ -179,6 +179,16 @@ AutoWrappingText::AutoWrappingText(wxWindow *parent, const wxString& label)
     Bind(wxEVT_SIZE, &AutoWrappingText::OnSize, this);
 }
 
+void AutoWrappingText::SetLabel(const wxString& label) {
+    wxString escapedLabel(label);
+
+    // Escape '&' to avoid wxStaticText treating it
+    // as if to mark an accelerator key (Windows),
+    // or not showing it at all (Mac).
+    escapedLabel.Replace("&", "&&");
+    wxStaticText::SetLabel(escapedLabel);
+}
+
 void AutoWrappingText::SetLanguage(Language lang)
 {
     m_language = lang;

--- a/src/customcontrols.h
+++ b/src/customcontrols.h
@@ -62,6 +62,8 @@ public:
 
     bool InformFirstDirection(int direction, int size, int availableOtherDir) override;
 
+    void SetLabel(const wxString& label) override;
+
 protected:
     void OnSize(wxSizeEvent& e);
     bool RewrapForWidth(int width);


### PR DESCRIPTION
Fixes the following issue:
If you have a comment containing an ampersand (&) in the comment
sidebar, it would be treated as an accelerator, i.e. the ampersand
would not be shown, and the character after it would be underlined
(on Windows), or not (on Mac).