### PR TITLE
preliminary Diff implementation for #230 (draft)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Checkout submodules
       # submodules are not used by the build, but needed for `make dist`:
-      run: git submodule update --init deps/json deps/pugixml
+      run: git submodule update --init deps/json deps/pugixml deps/dtl
     - name: Install dependencies
       run: |
         sudo apt-get update && \

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,6 +26,9 @@
 [submodule "deps/pugixml"]
 	path = deps/pugixml
 	url = https://github.com/zeux/pugixml.git
+[submodule "deps/dtl"]
+	path = deps/dtl
+	url = https://github.com/cubicdaiya/dtl
 [submodule "deps/boost-subset"]
 	path = deps/boost
 	url = https://github.com/poedit/boost-subset.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,15 @@ dist_metainfo_DATA = net.poedit.Poedit.appdata.xml
 EXTRA_DIST = \
 	deps/json/LICENSE.MIT \
 	deps/json/single_include/nlohmann/json.hpp \
+	deps/dtl/COPYING \
+	deps/dtl/dtl/Diff3.hpp \
+	deps/dtl/dtl/Diff.hpp \
+	deps/dtl/dtl/dtl.hpp \
+	deps/dtl/dtl/functors.hpp \
+	deps/dtl/dtl/Lcs.hpp \
+	deps/dtl/dtl/Sequence.hpp \
+	deps/dtl/dtl/Ses.hpp \
+	deps/dtl/dtl/variables.hpp \
 	deps/pugixml/LICENSE.md \
 	deps/pugixml/src/pugiconfig.hpp \
 	deps/pugixml/src/pugixml.cpp \

--- a/configure.ac
+++ b/configure.ac
@@ -240,12 +240,6 @@ PKG_CHECK_MODULES([PUGIXML], [pugixml >= 1.9],
             dnl use bundled copy
         ])
 
-AC_CHECK_HEADERS([dtl/dtl.hpp],
-        [ ],
-        [
-            AC_MSG_ERROR([missing dtl c++ header-only library])
-        ])
-
 
 dnl Check for Compact Language Detector 2
 dnl (used for better language detection and for non-English source languages)

--- a/configure.ac
+++ b/configure.ac
@@ -180,7 +180,6 @@ PKG_CHECK_MODULES([ICU], [icu-uc icu-i18n >= 54],
             AC_MSG_ERROR([missing ICU library])
         ])
 
-
 dnl we need GtkSpell and GTK+ >= 2 for this, check if we're compatible
 AC_MSG_CHECKING([if wxWidgets toolkit uses GTK+ 3])
 AC_COMPILE_IFELSE(
@@ -239,6 +238,12 @@ PKG_CHECK_MODULES([PUGIXML], [pugixml >= 1.9],
         ],
         [
             dnl use bundled copy
+        ])
+
+AC_CHECK_HEADERS([dtl/dtl.hpp],
+        [ ],
+        [
+            AC_MSG_ERROR([missing dtl c++ header-only library])
         ])
 
 

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -134,10 +134,11 @@ public:
         : SidebarBlock(parent, _("Previous source text"))
     {
         m_innerSizer->AddSpacer(PX(2));
-        m_innerSizer->Add(new ExplanationLabel(parent, _("The old source text (before it changed during an update) that the now-inaccurate translation corresponds to.")),
+        m_innerSizer->Add(new ExplanationLabel(parent, _("The difference to old source text (before it changed during an update) that the now-inaccurate translation corresponds to.")),
                      wxSizerFlags().Expand());
         m_innerSizer->AddSpacer(PX(5));
-        m_text = new SelectableAutoWrappingText(parent, WinID::PreviousSourceText, "");
+        //m_text = new SelectableAutoWrappingText(parent, WinID::PreviousSourceText, "");
+        m_text = new wxStaticText(parent, wxID_ANY, "");
         m_innerSizer->Add(m_text, wxSizerFlags().Expand());
     }
 
@@ -148,11 +149,15 @@ public:
 
     void Update(const CatalogItemPtr& item) override
     {
-        m_text->SetAndWrapLabel(item->GetOldMsgid());
+        //m_text->SetAndWrapLabel(item->GetOldMsgid());
+        m_text->SetLabelMarkup(Diff(item->GetOldMsgid(), item->GetString()).getMarkup());
+        m_text->SetMinSize(wxSize(-1, 50));
+
     }
 
 private:
-    SelectableAutoWrappingText *m_text;
+    //SelectableAutoWrappingText *m_text;
+    wxStaticText *m_text;
 };
 
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -44,7 +44,7 @@
     #include <unistd.h>
 #endif
 
-#include <dtl/dtl.hpp>
+#include "../deps/dtl/dtl/dtl.hpp"
 
 #include "str_helpers.h"
 
@@ -119,7 +119,7 @@ wxFileName MakeFileName(const wxString& path)
     return fn;
 }
 
-/// A convertor from dtl's to 
+/// A convertor from dtl's to our own diff action type
 Diff::Action dtl2DiffAction(dtl::edit_t lastType) {
     switch (lastType) {
         case dtl::SES_DELETE: return Diff::Action::Delete;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -132,7 +132,7 @@ Diff::Action dtl2DiffAction(dtl::edit_t lastType) {
 
 Diff::Diff(const wxString& from, const wxString& to) {
     // Do the diff
-    dtl::Diff<wxUniChar, wxString> d(from, to);
+    dtl::Diff<wchar_t, wxString> d(from, to);
     d.compose();
     auto dtlSeq = d.getSes().getSequence();
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -33,6 +33,7 @@
 #endif
 
 #include <map>
+#include <vector>
 
 #include <wx/arrstr.h>
 #include <wx/filename.h>
@@ -200,6 +201,39 @@ inline wxString MaskForType(const char *extensions, const wxString& description,
         return wxString::Format("%s|%s", description, extensions);
 }
 
+/// A helper class to calculate a display diff of strings
+class Diff
+{
+public:
+    /// Constructs a Diff object with a edit sequence from a string
+    /// @arg from to the string @arg to
+    Diff(const wxString& from, const wxString& to);
+
+    /// A type of element in the shortest edit sequence
+    enum class Action {
+        Common,  ///< symbols are the same
+        Add,     ///< symbols were added
+        Delete   ///< symbols were removed
+    };
+
+    /// An element from the shortest edit sequence
+    typedef std::pair<Action, wxString> sequenceElement;
+    /// A type to represent a shortest edit sequence i.e. the sequence of
+    /// substrings with an action (add remove, don't change) attached to them
+    typedef std::vector<sequenceElement> sequence;
+
+    /// @returns the shortest edit sequence in a form suitable for interpretation
+    const sequence& getSes() { return ses; };
+
+    /// @returns the diff ready to be displayed as a markup
+    /// @arg addColor    a background color for a string being added
+    /// @arg deleteColor a background color for a string being removed
+    wxString getMarkup(const wxString& addColor=wxString("lightgreen"),
+                       const wxString& deleteColor=wxString("pink"));
+
+private:
+    sequence ses;
+};
 
 #if wxUSE_GUI && defined(__WXMSW__)
 bool IsRunningUnderScreenReader();
@@ -266,7 +300,6 @@ public:
     wxString m_filenameTmp;
     wxString m_filenameFinal;
 };
-
 
 #ifdef __WXMSW__
 /// Return filename safe for passing to CLI tools (gettext).


### PR DESCRIPTION
TODO:

* [ ] `wxStaticText` resizing (and text rewrapping) should be reimplemented.
* [ ] Add settings for colour of diff text background in UI (people with dark UI theme will likely want to change those).
* [ ] Add context menu option to copy old source text.

Note: It assumes dtl is installed system-wide during build. Feel free to change it if you are going to package it with tarballs.