### PR TITLE
Do not install icon cache upon staged install

### DIFF
--- a/artwork/Makefile.am
+++ b/artwork/Makefile.am
@@ -48,7 +48,7 @@ dist_uiicons_DATA = \
 		window-close.png
 
 update-icon-cache:
-	which gtk-update-icon-cache >/dev/null && gtk-update-icon-cache -f -t $(DESTDIR)$(iconsdir) || true
+	test -z $(DESTDIR) && which gtk-update-icon-cache >/dev/null && gtk-update-icon-cache -f -t $(iconsdir) || true
 
 install-data-hook: update-icon-cache
 uninstall-hook: update-icon-cache


### PR DESCRIPTION
Upon installation, updating icon cache is relevant so that new icons can be found by the system.

Upon a [staged installation](https://www.gnu.org/software/automake/manual/html_node/Staged-Installs.html) though, i.e. when `DESTDIR` is set to a staging installation area, it is not relevant to update the icon cache as this cache is not the actual target system's cache.

Staged installation is typically used when creating a package of the application. Cache update is a problem well known to packagers which typically handle it by wrapping cache update commands into scripts to be executed at post (un)installation time - on the real target system.

See also:
- #703
- [The tutorial](https://ptomato.name/advanced-gtk-techniques/html/desktop-file.html) referenced in the ticket which actually mentions this tricky staged install case