### PR TITLE
Change git URLs to HTTPS in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,13 +8,13 @@
 	ignore = untracked
 [submodule "deps/lucene/LucenePlusPlus"]
 	path = deps/lucene/LucenePlusPlus
-	url = git://github.com/vslavik/LucenePlusPlus.git
+	url = https://github.com/vslavik/LucenePlusPlus.git
 [submodule "deps/zlib"]
 	path = deps/zlib
-	url = git://github.com/madler/zlib.git
+	url = https://github.com/madler/zlib.git
 [submodule "deps/letsmove"]
 	path = deps/letsmove
-	url = git://github.com/GroundControl-Solutions/LetsMove.git
+	url = https://github.com/GroundControl-Solutions/LetsMove.git
 [submodule "deps/cld2"]
 	path = deps/cld2
 	url = https://github.com/CLD2Owners/cld2.git


### PR DESCRIPTION
Unencrypted git:// protocol is no longer supported and errors out when trying to pull `letsmove`, `LucenePlusPlus` and `zlib` submodules
More info here: https://github.blog/2021-09-01-improving-git-protocol-security-github/