### PR TITLE
Fix sizing of the ID column on wxGTK

### DIFF
--- a/src/edlistctrl.cpp
+++ b/src/edlistctrl.cpp
@@ -177,10 +177,12 @@ public:
      */
     int GetWidth() const override
     {
+#if !wxCHECK_VERSION(3,1,3)
         // workaround a wx bug where it calculates width of hidden columns
         // see https://github.com/wxWidgets/wxWidgets/commit/560a81b913f23800e286d297d8cd38e72a207641
         if ( IsHidden() )
             return 0;
+#endif
 
         if ( fixed_width != wxCOL_WIDTH_DEFAULT )
             return fixed_width;

--- a/src/edlistctrl.h
+++ b/src/edlistctrl.h
@@ -306,6 +306,7 @@ class PoeditListCtrl : public wxDataViewCtrl
         void UpdateHeaderAttrs();
         void CreateColumns();
         void UpdateColumns();
+        void FixIdColumnSize();
         void OnSize(wxSizeEvent& event);
 
         bool m_displayIDs;


### PR DESCRIPTION
This is a naive attempt to fix the sizing issues of the ID column observed with wxGTK and reported in #643 and #714.

Basically:

- Sizing computation is delayed, so we can't fix the width immediately until we're sure it has been computed
- Despite being fixed, last column automatically grows and `wxDataViewColumn::GetWidth()` returns the actual width, not the fixed width, so we need a way to memorize the fixed width ourselves. I've created a custom `wxDataViewColumn` for that, I'm not sure it's the best approach though

I've tested this with the following environment:

- wxGTK version: 3.1.6
- GTK+ version: 3.24.33
- Operating system: openSUSE Tumbleweed (20220414)