### PR TITLE
Do not try to rescale recent file icon when it cannot be loaded

### DIFF
--- a/src/recent_files.cpp
+++ b/src/recent_files.cpp
@@ -174,7 +174,7 @@ private:
 #ifndef __WXMSW__
         // There is no guarantee that the desired size given at icon construction
         // has been taken into account - only wxMSW seems to use it
-        if (icon.GetWidth() != desiredSize || icon.GetHeight() != desiredSize)
+        if (icon.IsOk() && (icon.GetWidth() != desiredSize || icon.GetHeight() != desiredSize))
         {
             wxImage image = icon.ConvertToImage();
             image.Rescale(desiredSize, desiredSize, wxIMAGE_QUALITY_HIGH);


### PR DESCRIPTION
Recent file icon loading may fail e.g. because of missing read
permission or other packaging issue.

Icon rescale code introduced by 5fc8d6c did not foresee this
possibility.

Add a condition to prevent it from manipulating a non-ok icon.

This prevents assertion error although icon loading failure will still
lead to an error message showed to user.

See #758.