### PR TITLE
Skip files that do not exist

### DIFF
--- a/src/extractors/extractor.cpp
+++ b/src/extractors/extractor.cpp
@@ -120,6 +120,8 @@ int FindInDir(const wxString& basepath, const wxString& dirname, const PathsToMa
         if (excludedPaths.MatchesFile(fullpath))
             continue;
 
+        // Normally, a file enumerated by wxDir exists, but in one special case, it may
+        // not: if it is a broken symlink. FileExists() follows the symlink to check.
         if (!wxFileName::FileExists(basepath + fullpath))
             continue;
         

--- a/src/extractors/extractor.cpp
+++ b/src/extractors/extractor.cpp
@@ -120,6 +120,9 @@ int FindInDir(const wxString& basepath, const wxString& dirname, const PathsToMa
         if (excludedPaths.MatchesFile(fullpath))
             continue;
 
+        if (!wxFileName::FileExists(basepath + fullpath))
+            continue;
+        
         CheckReadPermissions(basepath, fullpath);
         wxLogTrace("poedit.extractor", "  - %s", fullpath);
         output.push_back(fullpath);


### PR DESCRIPTION
 Fixes the issue for cases when you are trying to update from source code and one of the files is a link to non-existing, which led to Permission denied exception.