### PR TITLE
Fix chmod/chown return code verification logic

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -302,9 +302,9 @@ bool TempOutputFileFor::ReplaceFile(const wxString& temp, const wxString& dest)
   #ifdef __UNIX__
     if (overwrite)
     {
-        if (!chown(destPath, st.st_uid, st.st_gid))
+        if (chown(destPath, st.st_uid, st.st_gid) != 0)
             return false;
-        if (!chmod(destPath, st.st_mode))
+        if (chmod(destPath, st.st_mode) != 0)
             return false;
     }
   #endif


### PR DESCRIPTION
On Linux, `TempOutputFileFor::ReplaceFile` returns a wrong status, indicating the replacement has failed when it has not. This leads to a misleading error message displayed to user on every po file save.

The cause is in the verification of the return codes of `chown`/`chmod`. `chown` and `chmod` return a non-zero integer value when an error occurs. A non-zero value is considered as a boolean `true`.

This commit fixes the logic error; It explicitly compares the returned integer value to another integer to avoid confusion.