### PR TITLE
Regenerate patch files for gettext 0.21.1

### DIFF
--- a/deps/gettext/gettext-macos-catalina-dont-touch-parent-dirs.patch
+++ b/deps/gettext/gettext-macos-catalina-dont-touch-parent-dirs.patch
@@ -3,48 +3,48 @@ executables, as done by gettext tools, triggers UAC prompts if the hosting app
 happens to be in e.g. ~/Desktop or ~/Downloads. As we don't care for these
 capabilities in gettext tools anyway, just disable them as the lesser evil.
 
-diff -ru gettext-0.20.2.orig/gettext-runtime/configure gettext-0.20.2/gettext-runtime/configure
---- gettext-0.20.2.orig/gettext-runtime/configure	2020-04-14 06:45:37.000000000 +0200
-+++ gettext-0.20.2/gettext-runtime/configure	2020-05-07 19:27:29.000000000 +0200
-@@ -20727,7 +20727,7 @@
+diff -ru gettext-0.21.1.orig/gettext-runtime/configure gettext-0.21.1/gettext-runtime/configure
+--- gettext-0.21.1.orig/gettext-runtime/configure	2022-10-09 16:31:34.000000000 -0500
++++ gettext-0.21.1/gettext-runtime/configure	2023-02-07 12:18:37.000000000 -0600
+@@ -25602,7 +25602,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFPreferences.h>
 +#include <Disabled_CoreFoundation/CFPreferences.h>
  int
- main ()
+ main (void)
  {
-@@ -20761,7 +20761,7 @@
+@@ -25638,7 +25638,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFLocale.h>
 +#include <Disabled_CoreFoundation/CFLocale.h>
  int
- main ()
+ main (void)
  {
-@@ -21184,7 +21184,7 @@
+@@ -26149,7 +26149,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFPreferences.h>
 +#include <Disabled_CoreFoundation/CFPreferences.h>
  int
- main ()
+ main (void)
  {
-@@ -21218,7 +21218,7 @@
+@@ -26185,7 +26185,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFLocale.h>
 +#include <Disabled_CoreFoundation/CFLocale.h>
  int
- main ()
+ main (void)
  {
-diff -ru gettext-0.20.2.orig/gettext-runtime/m4/intlmacosx.m4 gettext-0.20.2/gettext-runtime/m4/intlmacosx.m4
---- gettext-0.20.2.orig/gettext-runtime/m4/intlmacosx.m4	2020-04-13 10:42:28.000000000 +0200
-+++ gettext-0.20.2/gettext-runtime/m4/intlmacosx.m4	2020-05-07 19:27:29.000000000 +0200
+diff -ru gettext-0.21.1.orig/gettext-runtime/m4/intlmacosx.m4 gettext-0.21.1/gettext-runtime/m4/intlmacosx.m4
+--- gettext-0.21.1.orig/gettext-runtime/m4/intlmacosx.m4	2022-10-08 21:35:42.000000000 -0500
++++ gettext-0.21.1/gettext-runtime/m4/intlmacosx.m4	2023-02-07 12:18:37.000000000 -0600
 @@ -24,7 +24,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       AC_LINK_IFELSE(
@@ -63,42 +63,42 @@ diff -ru gettext-0.20.2.orig/gettext-runtime/m4/intlmacosx.m4 gettext-0.20.2/get
            [[CFLocaleCopyPreferredLanguages();]])],
         [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
         [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
-diff -ru gettext-0.20.2.orig/gettext-tools/configure gettext-0.20.2/gettext-tools/configure
---- gettext-0.20.2.orig/gettext-tools/configure	2020-04-14 03:34:46.000000000 +0200
-+++ gettext-0.20.2/gettext-tools/configure	2020-05-07 19:27:29.000000000 +0200
-@@ -23270,7 +23270,7 @@
+diff -ru gettext-0.21.1.orig/gettext-tools/configure gettext-0.21.1/gettext-tools/configure
+--- gettext-0.21.1.orig/gettext-tools/configure	2022-10-09 16:32:05.000000000 -0500
++++ gettext-0.21.1/gettext-tools/configure	2023-02-07 12:18:37.000000000 -0600
+@@ -28356,7 +28356,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFPreferences.h>
 +#include <Disabled_CoreFoundation/CFPreferences.h>
  int
- main ()
+ main (void)
  {
-@@ -23304,7 +23304,7 @@
+@@ -28392,7 +28392,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFLocale.h>
 +#include <Disabled_CoreFoundation/CFLocale.h>
  int
- main ()
+ main (void)
  {
-@@ -23727,7 +23727,7 @@
+@@ -28903,7 +28903,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFPreferences.h>
 +#include <Disabled_CoreFoundation/CFPreferences.h>
  int
- main ()
+ main (void)
  {
-@@ -23761,7 +23761,7 @@
+@@ -28939,7 +28939,7 @@
       LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
 -#include <CoreFoundation/CFLocale.h>
 +#include <Disabled_CoreFoundation/CFLocale.h>
  int
- main ()
+ main (void)
  {

--- a/deps/gettext/gettext-smaller-build.patch
+++ b/deps/gettext/gettext-smaller-build.patch
@@ -1,6 +1,6 @@
-diff -ru gettext-0.20.1.orig/gettext-runtime/Makefile.am gettext-0.20.1/gettext-runtime/Makefile.am
---- gettext-0.20.1.orig/gettext-runtime/Makefile.am	2019-04-04 03:51:10.000000000 +0200
-+++ gettext-0.20.1/gettext-runtime/Makefile.am	2019-09-21 17:48:17.000000000 +0200
+diff -ru gettext-0.21.1.orig/gettext-runtime/Makefile.am gettext-0.21.1/gettext-runtime/Makefile.am
+--- gettext-0.21.1.orig/gettext-runtime/Makefile.am	2019-05-11 06:29:32.000000000 -0500
++++ gettext-0.21.1/gettext-runtime/Makefile.am	2023-02-07 12:17:33.000000000 -0600
 @@ -27,7 +27,7 @@
  else
  SUBDIR_libasprintf =
@@ -10,9 +10,9 @@ diff -ru gettext-0.20.1.orig/gettext-runtime/Makefile.am gettext-0.20.1/gettext-
  
  EXTRA_DIST = BUGS
  
-diff -ru gettext-0.20.1.orig/gettext-tools/Makefile.am gettext-0.20.1/gettext-tools/Makefile.am
---- gettext-0.20.1.orig/gettext-tools/Makefile.am	2019-04-04 03:47:14.000000000 +0200
-+++ gettext-0.20.1/gettext-tools/Makefile.am	2019-09-21 17:50:46.000000000 +0200
+diff -ru gettext-0.21.1.orig/gettext-tools/Makefile.am gettext-0.21.1/gettext-tools/Makefile.am
+--- gettext-0.21.1.orig/gettext-tools/Makefile.am	2022-09-10 20:11:07.000000000 -0500
++++ gettext-0.21.1/gettext-tools/Makefile.am	2023-02-07 12:17:33.000000000 -0600
 @@ -19,7 +19,7 @@
  AUTOMAKE_OPTIONS = 1.5 gnu no-dependencies
  ACLOCAL_AMFLAGS = -I m4 -I ../gettext-runtime/m4 -I ../m4 -I gnulib-m4 -I libgrep/gnulib-m4 -I libgettextpo/gnulib-m4


### PR DESCRIPTION
Fixes build failure on macOS 13 whose patch program does not apply fuzzy patches.

Fixes #781