### PR TITLE
Add accessibility support to SwitchButton on Windows

### DIFF
--- a/src/custom_buttons.cpp
+++ b/src/custom_buttons.cpp
@@ -413,7 +413,7 @@ SwitchButton::SwitchButton(wxWindow *parent, wxWindowID winid, const wxString& l
     Bind(wxEVT_LEFT_DOWN, &SwitchButton::OnMouseClick, this);
 #if wxUSE_ACCESSIBILITY
     Bind(wxEVT_TOGGLEBUTTON, [=](wxCommandEvent& e) {
-        wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_STATECHANGE, wxDynamicCast(this, wxWindow), wxOBJID_CLIENT, wxACC_SELF);
+        wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_STATECHANGE, this, wxOBJID_CLIENT, wxACC_SELF);
         e.Skip();
     });
 #endif // wxUSE_ACCESSIBILITY
@@ -582,7 +582,7 @@ wxAccStatus SwitchButton::accessible::GetState(int childId, long* state)
     {
         return wxAccessible::GetState(childId, state);
     }
-    auto window = wxDynamicCast(this->GetWindow(), SwitchButton);
+    auto window = dynamic_cast<SwitchButton*>(this->GetWindow());
     if (window->IsFocusable())
     {
         *state |= wxACC_STATE_SYSTEM_FOCUSABLE;

--- a/src/custom_buttons.cpp
+++ b/src/custom_buttons.cpp
@@ -411,8 +411,23 @@ SwitchButton::SwitchButton(wxWindow *parent, wxWindowID winid, const wxString& l
     SetBackgroundColour(parent->GetBackgroundColour());
     MakeOwnerDrawn();
     Bind(wxEVT_LEFT_DOWN, &SwitchButton::OnMouseClick, this);
-#endif
+#if wxUSE_ACCESSIBILITY
+    Bind(wxEVT_TOGGLEBUTTON, [=](wxCommandEvent& e) {
+        wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_STATECHANGE, wxDynamicCast(this, wxWindow), wxOBJID_CLIENT, wxACC_SELF);
+        e.Skip();
+    });
+#endif // wxUSE_ACCESSIBILITY
+#endif // __WXMSW__
 }
+
+#ifdef __WXMSW__
+#if wxUSE_ACCESSIBILITY
+wxAccessible* SwitchButton::CreateAccessible() 
+{
+    return new accessible(this);
+}
+#endif // wxUSE_ACCESSIBILITY
+#endif // __WXMSW__
 
 void SwitchButton::SetColors(const wxColour& on, const wxColour& offLabel)
 {
@@ -549,6 +564,49 @@ bool SwitchButton::MSWOnDraw(WXDRAWITEMSTRUCT *wxdis)
 
     return true;
 }
+
+#if wxUSE_ACCESSIBILITY
+wxAccStatus SwitchButton::accessible::GetRole(int childId, wxAccRole* role)
+{
+    if (childId != wxACC_SELF)
+    {
+        return wxAccessible::GetRole(childId, role);
+    }
+    *role = wxROLE_SYSTEM_CHECKBUTTON;
+    return wxACC_OK;
+}
+
+wxAccStatus SwitchButton::accessible::GetState(int childId, long* state)
+{
+    if (childId != wxACC_SELF)
+    {
+        return wxAccessible::GetState(childId, state);
+    }
+    auto window = wxDynamicCast(this->GetWindow(), SwitchButton);
+    if (window->IsFocusable())
+    {
+        *state |= wxACC_STATE_SYSTEM_FOCUSABLE;
+    }
+    if (!window->IsShown())
+    {
+        *state |= wxACC_STATE_SYSTEM_INVISIBLE;
+    }
+    if (window->GetValue())
+    {
+        *state |= wxACC_STATE_SYSTEM_CHECKED;
+    }
+    if (!window->IsEnabled())
+    {
+        *state |= wxACC_STATE_SYSTEM_UNAVAILABLE;
+    }
+    if (window->HasFocus())
+    {
+        *state |= wxACC_STATE_SYSTEM_FOCUSED;
+    }
+    return wxACC_OK;
+}
+
+#endif // wxUSE_ACCESSIBILITY
 
 #endif // __WXMSW__
 

--- a/src/custom_buttons.h
+++ b/src/custom_buttons.h
@@ -114,12 +114,24 @@ public:
     void SetColors(const wxColour& on, const wxColour& offLabel);
 
 #ifdef __WXMSW__
+#if wxUSE_ACCESSIBILITY
+    wxAccessible* CreateAccessible() override;
+#endif // wxUSE_ACCESSIBILITY
     bool ShouldInheritColours() const override { return true; }
     void OnMouseClick(wxMouseEvent& e);
     bool MSWOnDraw(WXDRAWITEMSTRUCT *wxdis) override;
     wxSize DoGetBestSize() const override;
 
 private:
+#if wxUSE_ACCESSIBILITY
+    class accessible : public wxAccessible
+    {
+    public:
+        accessible(SwitchButton* win) : wxAccessible(wxDynamicCast(win, wxWindow)) {}
+        wxAccStatus GetRole(int childId, wxAccRole* role) override;
+        wxAccStatus GetState(int childId, long* state) override;
+    };
+#endif // wxUSE_ACCESSIBILITY
     wxColour m_clrOn, m_clrOffLabel;
 #endif // __WXMSW__
 };


### PR DESCRIPTION
 Fixes #693 

### Issue summary
There is no reliable way for screen reader users to find out the fuzzy (needs work) status. After some research, the most likely cause is as follows:

1. SwitchButton is owner drawn and therefore sets the BS_OWNERDRAW window style
2. When BS_OWNERDRAW is set, all other window styles should be ignored [according to the docs](BS_OWNERDRAW)
3. The default MSAA implementation in Windows ignores other window styles. As it relies on window style to find out whether the button is either a push button or a check box, this information is lost, and MSAA treats the toggle as a plain button without checkable state.

### Solution
Implement a wxAccessible subclass as outlined in #696 

### Testing performed
Executed from source, ensured that the needs work button is reported as check box and that toggling the button is properly reported by the NVDA screen reader.