### PR TITLE
Uyghur language translation file added for Poedit.

### DIFF
--- a/locales/ug.po
+++ b/locales/ug.po
@@ -1,0 +1,2302 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Poedit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Poedit 2.1\n"
+"Report-Msgid-Bugs-To: help@poedit.net\n"
+"POT-Creation-Date: 2023-09-30 19:13+0200\n"
+"PO-Revision-Date: 2023-11-25 13:15-0500\n"
+"Last-Translator: Abduqadir Abliz <sahran@live.com>\n"
+"Language-Team: \n"
+"Language: ug\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.4.1\n"
+
+msgid "Hide this notification message"
+msgstr "بۇ ئۇقتۇرۇش ئۇچۇرىنى يوشۇر"
+
+msgid "Don’t Show Again"
+msgstr "قايتا كۆرسەتمە"
+
+msgid "Don’t show again"
+msgstr "قايتا كۆرسەتمە"
+
+#, c-format
+msgid "(New: %i, obsolete: %i)"
+msgstr "(%i يېڭى، %i كونا)"
+
+msgid "Collecting source files…"
+msgstr "مەنبە ھۆججىتىنى توپلاۋاتىدۇ…"
+
+msgid "Extracting translatable strings…"
+msgstr "تەرجىمە تىزىقىنى ئاجرىتىۋاتىدۇ…"
+
+msgid "Failed to load file with extracted translations."
+msgstr "ئاجراتقان تەرجىمە ھۆججەتنى يۈكلىيەلمىدى."
+
+msgid "Merging differences…"
+msgstr "پەرقنى بىرلەشتۈرۈۋاتىدۇ…"
+
+msgid "Updating translations"
+msgstr "تەرجىمىلەرنى يېڭىلاۋاتىدۇ"
+
+#, c-format
+msgid "The file “%s” couldn’t be opened."
+msgstr "ھۆججەت «%s» نى ئاچقىلى بولمىدى."
+
+msgid "Invalid file"
+msgstr "ھۆججەت ئىناۋەتسىز"
+
+#, c-format
+msgid "Malformed header: “%s”"
+msgstr "باش قىسمى كۆرۈمسىز: «%s»"
+
+msgid "PO Translation Files"
+msgstr "PO تەرجىمە ھۆججەتلەر"
+
+msgid "POT Translation Templates"
+msgstr "POT تەرجىمە ھۆججەتلەر"
+
+msgid "XLIFF Translation Files"
+msgstr "XLIFF تەرجىمە ھۆججەتلەر"
+
+msgid "JSON Translation Files"
+msgstr "JSON تەرجىمە ھۆججەتلەر"
+
+#. TRANSLATORS: "Flutter" is proper noun, name of a developer tool
+msgid "Flutter Translation Files"
+msgstr "Flutter تەرجىمە ھۆججەتلەر"
+
+msgid "All Translation Files"
+msgstr "ھەممە تەرجىمە ھۆججەتلەر"
+
+msgid "The file is in a format not recognized by Poedit."
+msgstr "بۇ ھۆججەتنىڭ پىچىمىنى Poedit تونىمىغان."
+
+msgid "This JSON file isn’t a translations file and cannot be edited in Poedit."
+msgstr "بۇ JSON ھۆججىتى تەرجىمە ھۆججىتى ئەمەس ھەمدە Poedit تا تەھرىرلىگىلى بولمايدۇ."
+
+#, c-format
+msgid "Reading file content failed with the following error: %s"
+msgstr "تۆۋەندىكى خاتالىق تۈپەيلىدىن ھۆججەت مەزمۇنى ئوقۇيالمىدى:  %s"
+
+#, c-format
+msgid ""
+"File “%s” is read-only and cannot be saved.\n"
+"Please save it under different name."
+msgstr ""
+"ھۆججەت «%s» نى ئوقۇشقىلا بولىدۇ ۋە ساقلىغىلى بولمايدۇ.\n"
+"باشقا ئاتتا ساقلاڭ."
+
+#, c-format
+msgid "Couldn’t save file %s."
+msgstr "%s ھۆججەتنى ساقلىيالمىدى."
+
+msgid "Screenshots:"
+msgstr "ئېكران كەسمىسى:"
+
+#, fuzzy, c-format
+msgid "%i line of file “%s” was not loaded correctly."
+msgid_plural "%i lines of file “%s” were not loaded correctly."
+msgstr[0] "ھۆججەت «%s» نىڭ %i-قۇرىنى توغرا يۈكلىيەلمىدى."
+
+#, fuzzy, c-format
+msgid "Line %d of file “%s” is corrupted (not valid %s data)."
+msgstr "ھۆججەت «%s» نىڭ %d-قۇرى بۇزۇلغان (ئىناۋەتلىك %s سانلىق مەلۇماتى يوق)."
+
+msgid "Broken PO file: singular form msgstr used together with msgid_plural"
+msgstr "PO ھۆججىتى بۇزۇلغان: بىرلىك شەكلىدە msgstr بىلەن msgid_plural بىللە ئىشلىتىلگەن"
+
+msgid "Broken PO file: plural form msgstr used without msgid_plural"
+msgstr "PO ھۆججىتى بۇزۇلغان: كۆپلۈك سان شەكلىدە msgstr ئىشلىتىپ msgid_plural ئىشلەتمىگەن"
+
+msgid "Couldn’t load the file, it is probably damaged."
+msgstr "ھۆججەتنى يۈكلىيەلمىدى، ئۇ بۇزۇلغان بولۇشى مۇمكىن."
+
+msgid "There were errors when loading the file. Some data may be missing or corrupted as the result."
+msgstr "ھۆججەتنى يۈكلەۋاتقاندا خاتالىق كۆرۈلدى.  بەزى سانلىق مەلۇماتلار كەم ياكى بۇزۇلغان بولۇشى مۇمكىن."
+
+msgid "There was a problem formatting the file nicely (but it was saved all right)."
+msgstr "ھۆججەت پىچىمىدا مەسىلە بار(ئەمما ئۇ مۇۋەپپەقىيەتلىك ساقلاندى)."
+
+#, c-format
+msgid ""
+"The file couldn’t be saved in “%s” charset as specified in translation settings.\n"
+"\n"
+"It was saved in UTF-8 instead and the setting was modified accordingly."
+msgstr ""
+"تەرجىمە تەڭشىكىدە بەلگىلەنگەندەك ھۆججەتنى «%s» ھەرپ توپلىمىدا ساقلىيالمايدۇ.\n"
+"\n"
+"ئۇنى UTF-8 ھەرپ توپلىمىدا ساقلىغاندىمۇ، تەڭشەك مۇناسىپ ئۆزگىرىدۇ."
+
+msgid "Error saving file"
+msgstr "ھۆججەتنى ساقلاشتا خاتالىق كۆرۈلدى"
+
+#, c-format
+msgid "“%s” is not a valid POT file."
+msgstr "«%s» ئىناۋەتلىك POT ھۆججىتى ئەمەس."
+
+#, c-format
+msgid "Error while loading XLIFF file: %s"
+msgstr "XLIFF ھۆججىتىنى يۈكلەۋاتقاندا خاتالىق كۆرۈلدى: %s"
+
+#, c-format
+msgid "unsupported version (%s)"
+msgstr "قوللىمايدىغان نەشرى (%s)"
+
+#. TRANSLATORS: Shown as error if a translation of XLIFF markup is not valid XML
+msgid "Broken markup in translation string."
+msgstr "تەرجىمە تىزىقىدىكى بەلگە خاتا."
+
+msgid "(Use default language)"
+msgstr "كۆڭۈلدىكى تىلنى ئىشلەت"
+
+msgid "Language selection"
+msgstr "تىل تاللاش"
+
+msgid "Select your preferred language"
+msgstr "ياقتۇرىدىغان تىلنى تاللاڭ"
+
+msgid "You must restart Poedit for this change to take effect."
+msgstr "بۇ ئۆزگەرتىش كۈچكە ئىگە بولۇشى ئۈچۈن Poedit نى چوقۇم قايتا قوزغىتىڭ."
+
+msgid "Add Account"
+msgstr "ھېسابات قوش"
+
+msgid "Add account"
+msgstr "ھېسابات قوش"
+
+#. TRANSLATORS: %s is online service name, e.g. "Crowdin" or "Localazy"
+#, c-format
+msgid "Learn more about %s"
+msgstr "%s ھەققىدىكى تەپسىلات"
+
+msgid "Connect Poedit with supported cloud localization platforms to seamlessly sync translations managed on them."
+msgstr "Poedit نى قوللايدىغان بۇلۇت يەرلىكلەشتۈرۈش سۇپىلىرى بىلەن باغلاپ ئۇنىڭدىكى تەرجىمىلەرنى يوچۇقسىز قەدەمداشلىيالايسىز."
+
+msgid "How does cloud sync work?"
+msgstr "بۇلۇت قەدەمداش قانداق ئىشلەيدۇ؟"
+
+msgid "Account"
+msgstr "ھېسابات"
+
+msgid "(not signed in)"
+msgstr "(تىزىمغا كىرمىگەن)"
+
+msgid "File"
+msgstr "ھۆججەت"
+
+msgid "Open cloud translation"
+msgstr "بۇلۇت تەرجىمىسىنى ئاچ"
+
+msgid "Manage accounts"
+msgstr "ھېسابات باشقۇر"
+
+msgid "Project:"
+msgstr "قۇرۇلۇش:"
+
+msgid "Language:"
+msgstr "تىل:"
+
+msgid "Sign in to Cloud Account"
+msgstr "بۇلۇت ھېساباتقا تىزىمغا كىر"
+
+msgid "Sign in to cloud account"
+msgstr "بۇلۇت ھېساباتقا تىزىمغا كىر"
+
+msgid "No translation projects listed in your account."
+msgstr "ھېساباتىڭىزدا ھېچقانداق تەرجىمە قۇرۇلۇشى تېپىلمىدى."
+
+msgid "Downloading latest translations…"
+msgstr "ئاخىرقى تەرجىمىنى چۈشۈرۈۋاتىدۇ…"
+
+#. TRANSLATORS: "%s" is a name of online service, e.g. "Crowdin" or "Localazy"
+#, c-format
+msgid "Sign in to %s"
+msgstr "%s‎ غا تىزىمغا كىر"
+
+msgid "Syncing"
+msgstr "قەدەمداشلاۋاتىدۇ"
+
+#. TRANSLATORS: %s is a cloud destination, e.g. "Crowdin" or ftp.wordpress.com etc.
+#, c-format
+msgid "Uploading translations to %s…"
+msgstr "تەرجىمىلەرنى %s غا يۈكلەۋاتىدۇ…"
+
+#. TRANSLATORS: %s is a cloud destination, e.g. "Crowdin" or ftp.wordpress.com etc.
+#, c-format
+msgid "Uploading translations to %s failed."
+msgstr "تەرجىمىلەرنى %s غا يۈكلىيەلمىدى."
+
+msgid "Syncing error"
+msgstr "قەدەمداش خاتالىقى"
+
+msgid "Add"
+msgstr "قوش"
+
+msgid "Unknown Crowdin error."
+msgstr "يوچۇن Crowdin خاتالىقى."
+
+msgid "Not authorized, please sign in again."
+msgstr "ھوقۇق بېرىلمىگەن، قايتا تىزىمغا كىرىڭ."
+
+msgid "Downloading translations is disabled in this project."
+msgstr "بۇ قۇرۇلۇشتا تەرجىمە چۈشۈرۈش چەكلەنگەن."
+
+msgid "Sign In"
+msgstr "تىزىمغا كىر"
+
+msgid "Sign in"
+msgstr "تىزىمغا كىرىڭ"
+
+msgid "Sign Out"
+msgstr "تىزىمدىن چىق"
+
+msgid "Sign out"
+msgstr "تىزىمدىن چىق"
+
+msgid "Learn more about Crowdin"
+msgstr "Crowdin ھەققىدە تېخىمۇ كۆپ بىلدۈرگۈ"
+
+msgid "Crowdin is an online localization management platform and collaborative translation tool."
+msgstr "Crowdin توردىكى يەرلىكلەشتۈرۈشنى باشقۇرۇش سۇپىسى ۋە ھەمكارلىشىپ تەرجىمە قىلىش قورالى. "
+
+msgid "Waiting for authentication…"
+msgstr "دەلىللەشنى ساقلاۋاتىدۇ"
+
+msgid "Updating user information…"
+msgstr "ئىشلەتكۈچى ئۇچۇرىنى يېڭىلاۋاتىدۇ…"
+
+msgid "Sign in to Crowdin"
+msgstr "Crowdin غا تىزىمغا كىر"
+
+msgid "Syncing with Crowdin failed."
+msgstr "Crowdin بىلەن قەدامداشلىيالمىدى."
+
+msgid "Crowdin error"
+msgstr "Crowdin خاتالىقى"
+
+msgid "Uploading translations…"
+msgstr "تەرجىمىلەرنى يۈكلەۋاتىدۇ…"
+
+msgid "&Copy"
+msgstr "كۆچۈر(&C)"
+
+msgid "Learn more"
+msgstr "تەپسىلات بىلدۈرگۈسى"
+
+msgid "&Help"
+msgstr "ياردەم(&H)"
+
+msgid "MO files can’t be directly edited in Poedit."
+msgstr "Poedit تا MO ھۆججەتنى بىۋاسىتە تەھرىرلىگىلى بولمايدۇ."
+
+msgid "Error opening file"
+msgstr "ھۆججەت ئېچىش خاتالىقى"
+
+msgid "Please open and edit the corresponding PO file instead. When you save it, the MO file will be updated as well."
+msgstr "مۇناسىپ PO ھۆججەتنى ئېچىپ تەھرىرلەڭ. ئۇنى ساقلىغاندا، MO ھۆججىتىمۇ يېڭىلىنىدۇ."
+
+msgid "don’t delete temporary files (for debugging)"
+msgstr "ۋاقىتلىق ھۆججەتلەرنى ئۆچۈرمە (سازلاش ئۈچۈن)"
+
+msgid "handle a poedit:// URI"
+msgstr "poedit:// URI بىر تەرەپ قىلىش"
+
+msgid "go to item at given line number"
+msgstr "بەلگىلەنگەن قۇرغا يۆتكەل"
+
+msgid "Failed to communicate with Poedit process."
+msgstr "Poedit جەريانى بىلەن ئالاقە قىلالمىدى."
+
+#, c-format
+msgid "Unhandled exception occurred: %s"
+msgstr "بىر تەرەپ قىلغىلى بولمايدىغان مۇستەسنا يۈز بەردى: %s"
+
+msgid "Select translation template"
+msgstr "تەرجىمە قېلىپىنى تاللاڭ"
+
+msgid "Select translation file"
+msgstr "تەرجىمە ھۆججىتىنى تاللاڭ"
+
+msgid "Poedit is an easy to use translation editor."
+msgstr "Poedit ئىشلىتىش ئوڭاي تەرجىمە تەھرىرلىگۈچ."
+
+msgid "You can’t drop more than one file on Poedit window."
+msgstr "Poedit كۆزنىكىگە بىردىن ئارتۇق ھۆججەت تاشلىيالمايسىز."
+
+#, c-format
+msgid "File “%s” is not a translation file."
+msgstr "ھۆججەت «%s» تەرجىمە قىلىدىغان ھۆججەت ئەمەس."
+
+#, c-format
+msgid "File “%s” doesn’t exist."
+msgstr "ھۆججەت «%s» مەۋجۇت ئەمەس."
+
+msgid "Poedit"
+msgstr "Poedit"
+
+msgid "&Go"
+msgstr "يۆتكەل(&G)"
+
+#. TRANSLATORS: %s is language name in its basic form (as you
+#. would see e.g. in a list of supported languages). You may need
+#. to rephrase it, e.g. to an equivalent of "for language %s".
+#, c-format
+msgid "Spellchecking is disabled, because the dictionary for %s isn’t installed."
+msgstr "ئىملا تەكشۈرۈش چەكلەندى، چۈنكى %s ئۈچۈن لۇغەت ئورنىتىلمىغان."
+
+msgid "Install"
+msgstr "ئورنات"
+
+#, c-format
+msgid "The file “%s” has been changed by another application."
+msgstr "بۇ «%s» ھۆججەت باش ئەپتە ئۆزگەرتىلدى."
+
+msgid "Reload file"
+msgstr "ھۆججەتنى قايتا يۈكلە"
+
+msgid "Do you want to reload the file from disk? Your unsaved edits in Poedit will be lost if you do."
+msgstr "ھۆججەتنى دىسكىدىن يۈكلەمسىز؟ ئەگەر بۇنداق قىلسىڭىز Poedit تا ساقلىمىغان ئۆزگەرتىشلەر ساقلانمايدۇ."
+
+msgid "Ignore"
+msgstr "پەرۋا قىلما"
+
+msgid "Reload File"
+msgstr "ھۆججەتنى قايتا يۈكلە"
+
+msgid "The file has been modified. Do you want to save changes?"
+msgstr "ھۆججەت ئۆزگەرتىلدى. ئۆزگەرتىشنى ساقلامسىز؟"
+
+msgid "Save changes"
+msgstr "ئۆزگەرتكەننى ساقلا"
+
+msgid "Your changes will be lost if you don’t save them."
+msgstr "ئەگەر ساقلىمىسىڭىز ئۆزگەرتىشلەر يوقىلىدۇ."
+
+msgid "Save"
+msgstr "ساقلا"
+
+msgid "Do&n’t save"
+msgstr "ساقلىما(&N)"
+
+msgid "Don’t Save"
+msgstr "ساقلىما"
+
+msgid "The changes made by the other application will be lost if you save."
+msgstr "ئەگەر ساقلىسىڭىز باشقا ئەپتىكى ئۆزگەرتىشلەر يوقىلىدۇ."
+
+msgid "Cancel"
+msgstr "ۋاز كەچ"
+
+msgid "Save Anyway"
+msgstr "ساقلاۋەر"
+
+msgid "Save anyway"
+msgstr "ساقلاۋەر"
+
+msgid "Save as…"
+msgstr "باشقا ئاتتا ساقلا…"
+
+msgid "Compile to…"
+msgstr "ھاسىللا…"
+
+msgid "Compiled Translation Files"
+msgstr "تەرجىمە ھۆججەت ھاسىللاندى"
+
+msgid "Export as…"
+msgstr "سۈپىتىدە چىقار…"
+
+msgid "HTML Files"
+msgstr "HTML ھۆججەتلەر"
+
+#, c-format
+msgid "In: %s"
+msgstr "ئورنى: %s"
+
+msgid "Source code not available."
+msgstr "مەنبە كودىنى ئىشلەتكىلى بولمايدۇ."
+
+msgid "Updating failed"
+msgstr "يېڭىلىيالمىدى"
+
+msgid "Translations couldn’t be updated from the source code, because no code was found in the location specified in the file’s Properties."
+msgstr "تەرجىمىنى مەنبە كودتىن يېڭىلىيالمايدۇ، چۈنكى ھۆججەتتە بەلگىلەنگەن ئورۇندىن كود تېپىلمىدى."
+
+msgid "Permission denied."
+msgstr "ھوقۇق رەت قىلىندى."
+
+msgid "You don’t have permission to read source code files from the location specified in the file’s Properties."
+msgstr "ھۆججەت خاسلىقىدا بەلگىلەنگەن ئورۇندىكى مەنبە كود ھۆججىتىنى ئوقۇيدىغان ھوقۇقىڭىز يوق."
+
+#. TRANSLATORS: The System Settings etc. references macOS 13 Ventura or newer system settings and should be translated EXACTLY as in macOS. If you don't use macOS and can't check, please leave it untranslated.
+msgid "If you previously denied access to your files, you can allow it in System Settings > Privacy & Security > Files & Folders."
+msgstr "ئەگەر ئىلگىرى ھۆججىتىڭىزنى زىيارەت قىلىش ھوقۇقىنى رەت قىلغان بولسىڭىز، سىستېما تەڭشەكلەر › شەخسىيەت ۋە بىخەتەرلىك › ھۆججەت ۋە قىسقۇچتىن قايتىدىن زىيارەت قىلىشقا يول قويۇڭ."
+
+#. TRANSLATORS: The System Preferences etc. references macOS system settings and should be translated EXACTLY as in macOS. If you don't use macOS and can't check, please leave it untranslated.
+msgid "If you previously denied access to your files, you can allow it in System Preferences > Security & Privacy > Privacy > Files & Folders."
+msgstr "ئەگەر ئىلگىرى ھۆججىتىڭىزنى زىيارەت قىلىش ھوقۇقىنى رەت قىلغان بولسىڭىز، سىستېما مايىللىقلار › بىخەتەرلىك ۋە شەخسىيەت › شەخسىيەت › ھۆججەت ۋە قىسقۇچتىن قايتىدىن زىيارەت قىلىشقا يول قويۇڭ."
+
+msgid "Translation entries in the file are probably incorrect."
+msgstr "ھۆججەتتىكى تەرجىمە تۈرلەر توغرا بولماسلىقى مۇمكىن."
+
+msgid "Updating the file failed. Click on 'Details >>' for details."
+msgstr "ھۆججەتنى يېڭىلىيالمىدى. تەپسىلاتى ئۈچۈن «تەپسىلاتى››» نى چېكىڭ."
+
+msgid "Open translation template"
+msgstr "تەرجىمە قېلىپىنى ئاچ"
+
+#, c-format
+msgid "%d issue with the translation found."
+msgid_plural "%d issues with the translation found."
+msgstr[0] "تەرجىمىدە %d مەسىلە بايقالدى."
+
+msgid "Validation results"
+msgstr "دەلىللەش نەتىجىلىرى"
+
+msgid "Entries with errors were marked in red in the list. Details of the error will be shown when you select such an entry."
+msgstr "خاتالىق بار تۈرلەر تىزىمدا قىزىل رەڭدە بەلگە سېلىنىدۇ.  بۇ خىل تۈرنى تاللىسىڭىز خاتالىقنىڭ تەپسىلاتىنى كۆرسىتىدۇ."
+
+msgid "The file was saved safely."
+msgstr "ھۆججەت بىخەتەر ساقلاندى."
+
+msgid "The file was saved safely and compiled into the MO format, but it will probably not work correctly."
+msgstr " ھۆججەت بىخەتەر ساقلاندى ھەمدە MO پىچىمىدا ھاسىللاندى، ئەمما ئۇ ئادەتتىكىدەك توغرا ئىشلىمەسلىكى مۇمكىن."
+
+msgid "The file was saved safely, but it cannot be compiled into the MO format and used."
+msgstr "ھۆججەت بىخەتەر ساقلاندى ئەمما MO پىچىمىغا ھاسىللاپ ئىشلەتكىلى بولمايدۇ."
+
+msgid "The file was compiled into the MO format, but it will probably not work correctly."
+msgstr " ھۆججەت MO پىچىمىدا ھاسىللاندى، ئەمما ئۇ ئادەتتىكىدەك توغرا ئىشلىمەسلىكى مۇمكىن."
+
+msgid "The file cannot be compiled into the MO format and used."
+msgstr "ھۆججەتنى MO پىچىمىغا ھاسىللاپ ۋە ئىشلەتكىلى بولمايدۇ."
+
+msgid "No problems with the translation found."
+msgstr "تەرجىمىدە مەسىلە بايقالمىدى."
+
+#, c-format
+msgid "The translation is ready for use, but %d entry is not translated yet."
+msgid_plural "The translation is ready for use, but %d entries are not translated yet."
+msgstr[0] "تەرجىمە ئىشلىتىشكە تەييار بولدى، ئەمما %d تىزىق تېخى تەرجىمە قىلىنمىغان."
+
+msgid "The translation is ready for use."
+msgstr "تەرجىمە ئىشلىتىشكە تەييار بولدى."
+
+#, c-format
+msgid "Poedit automatically fixed invalid content in the file “%s”."
+msgstr "بۇ «%s» ھۆججەتتىكى ئىناۋەتسىز مەزمۇننى Poedit ئۆزلۈكىدىن تۈزەتتى."
+
+msgid "The file contained duplicate items, which is not allowed in PO files and would prevent the file from being used. Poedit fixed the issue, but you should review translations of any items marked as needing work and correct them if necessary."
+msgstr " بۇ ھۆججەتتە تەكرار تۈر بار، بۇنىڭغا يول قويۇلمايدۇ ھەمدە ئۇنىڭ ئىشلىتىلىشىگە تەسىر كۆرسىتىدۇ. بۇ مەسىلىنى Poedit ھەل قىلدى، ئەمما سىز «ئىشلەش زۆرۈر» بەلگىسى قويۇلغان ھەر قانداق تەرجىمىنى ئەگەر زۆرۈر بولسا تەكشۈرۈپ تۈزىتىڭ."
+
+msgid "Language of the translation isn’t set."
+msgstr "تەرجىمە تىلى تەڭشەلمىگەن."
+
+msgid "Set Language"
+msgstr "تىل تەڭشەش"
+
+msgid "Set language"
+msgstr "تىل تەڭشەش"
+
+#. TRANSLATORS: This is shown underneath "Language of the translation isn't set (or ...is the same as source language)."
+msgid "Suggestions are not available if the translation language is not set correctly. Other features, such as plural forms, may be affected as well."
+msgstr "ئەگەر تەرجىمە تىلى توغرا تەڭشەلمىگەن بولسا تەۋسىيەنى ئىشلەتكىلى بولمايدۇ. كۆپلۈك شەكىلگە ئوخشاش باشقا ئىقتىدارلارمۇ تەسىرگە ئۇچرىشى مۇمكىن."
+
+msgid "Language of the translation is the same as source language."
+msgstr "تەرجىمە تىلى ئەسلى تىل بىلەن ئوخشاش."
+
+msgid "Fix Language"
+msgstr "تىل ئوڭشا"
+
+msgid "Fix language"
+msgstr "تىل ئوڭشا"
+
+msgid "This file has entries with plural forms, but doesn’t have Plural-Forms header configured."
+msgstr "بۇ ھۆججەتنىڭ كۆپلۈك شەكلىدىكى تۈرلىرى بار ئىكەن ئەمما كۆپلۈك شەكلىنىڭ ھۆججەت بېشىدىكى سەپلىمىسى يوقكەن."
+
+msgid "Entries in this file have different plural forms count from what the file’s Plural-Forms header says"
+msgstr "ھۆججەت كۆپلۈك شەكىل بېشىدا ھۆججەت تۈرلىرىنىڭ ئوخشاش بولمىغان كۆپلۈك شەكلىدىكى سانىغۇچ تۈرلىرى بار ئىكەن"
+
+msgid "Required header Plural-Forms is missing."
+msgstr "ھۆججەت بېشىدىكى زۆرۈر بولغان كۆپلۈك شەكلى كەم."
+
+#, c-format
+msgid "Syntax error in Plural-Forms header (\"%s\")."
+msgstr "كۆپلۈك شەكلىنىڭ باشى(«%s»)دا گرامماتىكىلىق خاتالىق بار."
+
+msgid "Fix the Header"
+msgstr "باشنى ئوڭشا"
+
+msgid "Fix the header"
+msgstr "باشنى ئوڭشا"
+
+#. TRANSLATORS: %s is language name in its basic form (as you
+#. would see e.g. in a list of supported languages). You may need
+#. to rephrase it, e.g. to an equivalent of "for language %s".
+#, c-format
+msgid "Plural forms expression used by the file is unusual for %s."
+msgstr "بۇ ھۆججەتتە ئىشلىتىلگەن كۆپلۈك شەكلى %s غا نىسبەتەن ئالاھىدە."
+
+#. TRANSLATORS: A verb, shown as action button with ""Plural forms expression used by the file is unusual for %s.")"
+msgid "Review"
+msgstr "تەكشۈر"
+
+msgid "Would you like to use English for source text?"
+msgstr "مەنبە تېكىستكە ئىنگلىزچە ئىشلىتىشنى خالامسىز؟"
+
+#, c-format
+msgid "This file uses string IDs instead of source text. Poedit can load English texts from the “%s” file for you."
+msgstr "بۇ ھۆججەت مەنبە تېكىستنىڭ ئورنىغا ھەرپ تىزىقى ID نى ئىشلىتىدۇ. Poedit سىز ئۈچۈن «%s» ھۆججىتىدىن ئىنگلىزچە تېكىستنى يۈكلىيەلەيدۇ."
+
+#. TRANSLATORS: Shown as action button when asking if the user wants to replace string IDs with English text; "load" as in "load from file"
+msgid "Load English"
+msgstr "ئىنگلىزچە يۈكلە"
+
+#, c-format
+msgid "Translated: %d of %d (%d %%)"
+msgstr "تەرجىمە قىلىنغان: %d of %d (%d %%)"
+
+#, c-format
+msgid "Remaining: %d"
+msgstr "قالغىنى: %d"
+
+#, c-format
+msgid "%d error"
+msgid_plural "%d errors"
+msgstr[0] "%d خاتالىق"
+
+#, c-format
+msgid "%d entry"
+msgid_plural "%d entries"
+msgstr[0] "%d تىزىق"
+
+msgid " (unsaved)"
+msgstr " (ساقلانمىغان)"
+
+msgid " (modified)"
+msgstr " (ئۆزگەرتىلگەن)"
+
+#, c-format
+msgid "Failed to update translation memory: %s"
+msgstr "تەرجىمە خاتىرىسىنى يېڭىلىيالمىدى: %s"
+
+msgid "Purge deleted translations"
+msgstr "ئۆچۈرۈلگەن تەرجىمىنى تازىلا"
+
+msgid "Do you want to remove all translations that are no longer used?"
+msgstr "ئىشلىتىلمەيدىغان ھەممە تەرجىمىنى ئۆچۈرەمسىز؟"
+
+msgid "If you continue with purging, all translations marked as deleted will be permanently removed. You will have to translate them again if they are added back in the future."
+msgstr "ئەگەر تازىلاشنى داۋاملاشتۇرسىڭىز، ئۆچۈرۈلدى بەلگىسى سېلىنغان ھەممە تەرجىمە مەڭگۈلۈك ئۆچۈرۈلىدۇ. ئەگەر كەلگۈسىدە ئۇلارنى قايتا قوشسىڭىز يەنە باشتىن تەرجىمە قىلىشقا توغرا كېلىدۇ."
+
+msgid "Keep"
+msgstr "ساقلاپ قال"
+
+msgid "Purge"
+msgstr "تازىلا"
+
+msgid "Copy from source text"
+msgstr "ئەسلى تېكىستتىن كۆچۈر"
+
+msgid "Copy from Source Text"
+msgstr "ئەسلى تېكىستتىن كۆچۈر"
+
+#. TRANSLATORS: This is the key shortcut used in menus on Windows, some languages call them differently
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Ctrl+"
+msgstr "Ctrl+"
+
+msgid "Clear translation"
+msgstr "تەرجىمە تازىلا"
+
+msgid "Clear Translation"
+msgstr "تەرجىمە تازىلا"
+
+msgid "Edit comment"
+msgstr "ئىزاھات تەھرىر"
+
+msgid "Edit Comment"
+msgstr "ئىزاھات تەھرىر"
+
+#. TRANSLATORS: Meaning occurrences of the string in source code
+msgid "Code Occurrences"
+msgstr "كود كۆرۈنىدىغان ئورۇن"
+
+#. TRANSLATORS: Meaning occurrences of the string in source code
+msgid "Code occurrences"
+msgstr "كود كۆرۈنىدىغان ئورۇن"
+
+msgid "&Bookmarks"
+msgstr "خەتكۈچلەر(&B)"
+
+#. TRANSLATORS: This is the key shortcut used in menus on Windows, some languages call them differently
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Alt+"
+msgstr "Alt+"
+
+#, c-format
+msgid "Set bookmark %i"
+msgstr "خەتكۈچ تەڭشەك %i"
+
+#, c-format
+msgid "Go to bookmark %i"
+msgstr "خەتكۈچ %i گە يۈتكەل"
+
+#, c-format
+msgid "Set Bookmark %i"
+msgstr "خەتكۈچ تەڭشەك %i"
+
+#, c-format
+msgid "Go to Bookmark %i"
+msgstr "خەتكۈچ %i گە يۈتكەل"
+
+msgid "Hide Sidebar"
+msgstr "يان بالداقنى يوشۇر"
+
+msgid "Show Sidebar"
+msgstr "يان بالداقنى كۆرسەت"
+
+msgid "Hide Status Bar"
+msgstr "ھالەت بالداقنى يوشۇر"
+
+msgid "Show Status Bar"
+msgstr "ھالەت بالداق كۆرسەت"
+
+msgid "String length in characters: translation | source"
+msgstr "ھەرپ تىزىقى ئۇزۇنلۇقى: تەرجىمە | مەنبە"
+
+msgid "String length in characters"
+msgstr "ھەرپ تىزىقى ئۇزۇنلۇقى"
+
+msgid "Source text"
+msgstr "مەنبە تېكست"
+
+msgid "Singular"
+msgstr "بىرلىك"
+
+msgid "Plural"
+msgstr "كۆپلۈك"
+
+msgid "Translation"
+msgstr "تەرجىمىسى"
+
+msgid "Pre-translated"
+msgstr "ئالدىن تەرجىمە قىلىندى"
+
+msgid "Needs Work"
+msgstr "ئىشلەش زۆرۈر"
+
+#. TRANSLATORS: This indicates that the string's translation isn't final
+#. and has known problems.  For example, it might be machine translated or
+#. fuzzy matched from an older string. The translation should be short and
+#. convey this. If it's problematic to translate it, "Needs review" is
+#. acceptable substitute, but note that the meaning is subtly different:
+#. "needs review" implies that somebody else should review the string after
+#. I am done with it (i.e. consider it good), while "needs work" implies I
+#. need to return to it and finish the translation.
+msgid "Needs work"
+msgstr "ئىشلەش زۆرۈر"
+
+msgid ""
+"POT files are only templates and don’t contain any translations themselves.\n"
+"To make a translation, create a new PO file based on the template."
+msgstr ""
+"POT ھۆججەتلىرى پەقەتلا قېلىپ بولۇپ، ئۆزى ھېچقانداق تەرجىمىنى ئۆز ئىچىگە ئالمايدۇ.\n"
+" تەرجىمە قىلىش ئۈچۈن، قېلىپ ئاساسىدىكى يېڭى بىر PO ھۆججىتى قۇرۇڭ."
+
+msgid "Create new translation"
+msgstr "يېڭى تەرجىمە قۇر"
+
+msgid "Make a new translation from this POT file."
+msgstr "بۇ POT ھۆججەتتىن يېڭى تەرجىمە قۇرىدۇ."
+
+#. TRANSLATORS: Refers to symbolic ID of source text, i.e. when something like "button.label" is used instead of English text
+msgid "Source text ID"
+msgstr "مەنبە تېكىست ID"
+
+msgid "Everything"
+msgstr "ھەممىسى"
+
+#, c-format
+msgid "Form %i"
+msgstr "شەكىل %i"
+
+#, c-format
+msgid "Form %i (unused)"
+msgstr "شەكىل %i (ئىشلەتمىگەن)"
+
+msgid "Zero"
+msgstr "نۆل"
+
+msgid "One"
+msgstr "بىر"
+
+msgid "Two"
+msgstr "ئىككى"
+
+msgid "Other"
+msgstr "باشقا"
+
+#. TRANSLATORS: Tooltip on message context tag in the editing area, '%s' is the context text
+#, c-format
+msgid "String context: %s"
+msgstr "ھەرپ تىزىقى مەزمۇنى: %s"
+
+#. TRANSLATORS: Tooltip on string ID tag in the editing area, '%s' contains the ID
+#, c-format
+msgid "String identifier: %s"
+msgstr "ھەرپ تىزىقى پەرقلەندۈرگۈچ: %s"
+
+#, c-format
+msgid "%s Format"
+msgstr "%s پىچىم"
+
+#. TRANSLATORS: %s is replaced with language name, e.g. "PHP" or "C", so "PHP Format" etc."
+#, c-format
+msgid "%s format"
+msgstr "%s پىچىم"
+
+#, c-format
+msgid "Translation — %s"
+msgstr "تەرجىمە - %s"
+
+msgid "ID"
+msgstr "ID"
+
+#, c-format
+msgid "Source text — %s"
+msgstr "مەنبە تېكىست - %s"
+
+msgid "unknown language"
+msgstr "يوچۇن تىل"
+
+#, c-format
+msgid "Failed command: %s"
+msgstr "بۇيرۇق مەغلۇپ بولدى: %s"
+
+msgid "Failed to merge gettext catalogs."
+msgstr "gettext كاتالوگىنى بىرلەشتۈرەلمىدى."
+
+msgid "Open in Editor"
+msgstr "تەھرىرلىگۈچتە ئاچ"
+
+msgid "Open in editor"
+msgstr "تەھرىرلىگۈچتە ئاچ"
+
+msgid "No information about this string’s occurrences in the source code is provided in the file."
+msgstr "ھۆججەتتە بۇ ھەرپ تىزىقىنىڭ ئەسلى كودتا كۆرۈنىدىغان ئورۇن ئۇچۇرى تەمىنلەنمىگەن."
+
+msgid "No usage information"
+msgstr "ئىشلىتىش ئۇسۇلى ئۇچۇرى يوق"
+
+#, c-format
+msgid "%d code occurrence"
+msgid_plural "%d code occurrences"
+msgstr[0] "%d كودنىڭ كۆرۈنىدىغان ئورنى"
+
+msgid "Source code not found"
+msgstr "مەنبە كودى تېپىلمىدى"
+
+msgid "Poedit cannot show source code where the string is used, because the file is either not available in the referenced location or it is a symbolic reference that doesn’t point to a real file."
+msgstr "ھەرپ تىزىقىنىڭ ئەسلى كودنىڭ قايسى جايىدا ئىشلىتىلگەنلىكىنى Poedit كۆرسىتەلمەيدۇ، چۈنكى ھۆججەتنى نەقىل ئورنىدىنمۇ ئىشلەتكىلى بولمايدۇ ياكى ئۇ ئەمەلىي ھۆججەتنى نىشانلىمىغان بەلگە نەقىلى بولۇشى مۇمكىن."
+
+msgid "File cannot be opened"
+msgstr "ھۆججەتنى ئاچالمىدى"
+
+#, c-format
+msgid "Poedit was unable to open the “%s” file."
+msgstr "Poedit بۇ «%s» ھۆججەتنى ئاچالمىغان."
+
+msgid "Find"
+msgstr "ئىزدە"
+
+msgid "Replace"
+msgstr "ئالماشتۇر"
+
+#. TRANSLATORS: Expander in Find window for additional options (case sensitive etc.)
+msgid "Options"
+msgstr "تاللانمىلار"
+
+msgid "Ignore case"
+msgstr "چوڭ كىچىك يېزىلىشىغا پەرۋا قىلما"
+
+msgid "Wrap around"
+msgstr "تولۇق ماسلاش"
+
+msgid "Whole words only"
+msgstr "بارلىق سۆزلەرلا"
+
+msgid "Find in source texts"
+msgstr "ئەسلى تېكستتىن ئىزدە"
+
+msgid "Find in translations"
+msgstr "تەرجىمىدىن ئىزدە"
+
+msgid "Find in comments"
+msgstr "ئىزاھاتتىن ئىزدە"
+
+msgid "Close"
+msgstr "ياپ"
+
+msgid "Replace &All"
+msgstr "ھەممىنى ئالماشتۇر(&A)"
+
+msgid "Replace &all"
+msgstr "ھەممىنى ئالماشتۇر(&A)"
+
+msgid "&Replace"
+msgstr "ئالماشتۇر(&R)"
+
+msgid "< &Previous"
+msgstr "< ئالدىنقى(&P)"
+
+msgid "&Next >"
+msgstr "‹ كەينى(&N)"
+
+msgid "String to find"
+msgstr "ئىزدەيدىغان ھەرپ تىزىقى"
+
+msgid "Replacement string"
+msgstr "ئالمىشىدىغان تېكىست"
+
+#, c-format
+msgid "Cannot execute program: %s"
+msgstr "پروگراممىنى ئىجرا قىلالمايدۇ: %s"
+
+#. TRANSLATORS: placeholder/hint in language controls
+msgid "Language name or code"
+msgstr "تىل ئىسمى ياكى كودى"
+
+msgid "Translation Language"
+msgstr "تەرجىمە تىلى"
+
+msgid "Language of the translation:"
+msgstr "تەرجىمە تىلى:"
+
+msgid "All strings"
+msgstr "ھەممە ھەرپ تىزىقى"
+
+msgid "Couldn’t download Localazy project details."
+msgstr "Localazy قۇرۇلۇشىنىڭ تەپسىلاتىنى چۈشۈرەلمەيدۇ."
+
+msgid "There was an error when uploading translations to Localazy."
+msgstr "Localazy غا تەرجىمە يۈكلىگەندە خاتالىق كۆرۈلدى."
+
+msgid "Projects"
+msgstr "قۇرۇلۇشلار"
+
+msgid "Localazy is a highly automated localization platform allowing anyone to translate their products and content into multiple languages easily."
+msgstr "Localazy زور دەرىجىدە ئاپتوماتلاشتۇرۇلغان يەرلىكلەشتۈرۈش سۇپىسى بولۇپ ھەر قانداق كىشىنىڭ مەھسۇلات ۋە مەزمۇنلىرىنى كۆپ خىل تىلغا تەرجىمە قىلىشنى قۇلايلاشتۇرىدۇ."
+
+msgid "Add Project"
+msgstr "قۇرۇلۇش قوش"
+
+msgid "Add project"
+msgstr "قۇرۇلۇش قوش"
+
+msgid "Poedit - Catalogs manager"
+msgstr "Poedit - كاتالوگ باشقۇرغۇچ"
+
+msgid "Edit…"
+msgstr "تەھرىر…"
+
+msgid "Create new translations project"
+msgstr "يېڭى تەرجىمە قۇرۇلۇشى قۇر"
+
+msgid "Delete the project"
+msgstr "قۇرۇلۇش ئۆچۈر"
+
+msgid "Edit the project"
+msgstr "بۇ قۇرۇلۇشنى تەھرىرلە"
+
+msgid "Update all"
+msgstr "ھەممىنى يېڭىلا"
+
+msgid "Update all catalogs in the project"
+msgstr "قۇرۇلۇشتىكى بارلىق كاتالوگنى يېڭىلا"
+
+msgid "Total"
+msgstr "جەمئى"
+
+msgid "Untrans"
+msgstr "تەرجىمە قىلىنمىغان"
+
+msgctxt "column/row header"
+msgid "Needs Work"
+msgstr "ئىشلەش زۆرۈر"
+
+msgid "Errors"
+msgstr "خاتالىق"
+
+msgid "Last modified"
+msgstr "ئاخىرقى ئۆزگەرتىش"
+
+msgid "Select directory"
+msgstr "مۇندەرىجە تاللا"
+
+msgid "Directories:"
+msgstr "مۇندەرىجە:"
+
+msgid "<unnamed>"
+msgstr "<ئاتسىز>"
+
+#, c-format
+msgid "Do you want to delete project “%s”?"
+msgstr "قۇرۇلۇش «%s» نى ئۆچۈرەمسىز؟"
+
+msgid "Delete project"
+msgstr "قۇرۇلۇش ئۆچۈر"
+
+msgid "Deleting the project will not delete any translation files."
+msgstr "بۇ قۇرۇلۇش ئۆچۈرۈلسە ھېچقانداق تەرجىمە ھۆججىتىنى ئۆچۈرمەيدۇ."
+
+msgid "Confirmation"
+msgstr "جەزملە"
+
+msgid "Update all catalogs in this project?"
+msgstr "بۇ قۇرۇلۇشتىكى بارلىق كاتالوگنى يېڭىلامدۇ؟"
+
+msgid "Performs update from source code on all files in the project."
+msgstr "بۇ قۇرۇلۇشتىكى ھەممە ھۆججەتنى ئەسلى كودتىن يېڭىلايدۇ."
+
+msgid "Catalogs Manager"
+msgstr "كاتالوگ باشقۇرغۇچ"
+
+msgid "Check for Updates…"
+msgstr "يېڭىلاشنى تەكشۈر…"
+
+#. TRANSLATORS: This is Settings app menu that replaces Preferences in macOS 13 Ventura or newer, and should be translated EXACTLY as in macOS. If you don't use macOS and can't check, please leave it untranslated.
+msgid "Settings…"
+msgstr "تەڭشەكلەر…"
+
+msgid "&Edit"
+msgstr "تەھرىر(&E)"
+
+msgid "Undo"
+msgstr "يېنىۋال"
+
+msgid "Redo"
+msgstr "قايتىلا"
+
+msgid "Paste and Match Style"
+msgstr "چاپلاپ ئۇسلۇبقا ماسلاش"
+
+msgid "Delete"
+msgstr "ئۆچۈر"
+
+msgid "Spelling and Grammar"
+msgstr "ئىملا ۋە گرامماتىكا"
+
+msgid "Show Spelling and Grammar"
+msgstr "ئىملا ۋە گرامماتىكا كۆرسەت"
+
+msgid "Check Document Now"
+msgstr "پۈتۈكنى ھازىر تەكشۈر"
+
+msgid "Check Spelling While Typing"
+msgstr "خەت كىرگۈزۈۋاتقاندا ئىملا تەكشۈر"
+
+msgid "Check Grammar With Spelling"
+msgstr "ئىملا ۋە گرامماتىكا تەكشۈر"
+
+msgid "Correct Spelling Automatically"
+msgstr "ئىملانى ئۆزلۈكىدىن توغرىلا"
+
+msgid "Substitutions"
+msgstr "ئالماشتۇرىدىغان"
+
+msgid "Show Substitutions"
+msgstr "ئالماشتۇرىدىغاننى كۆرسەت"
+
+msgid "Smart Copy/Paste"
+msgstr "ئىدراكلىق كۆچۈر/چاپلا"
+
+msgid "Smart Quotes"
+msgstr "ئىدراكلىق قوش پەش"
+
+msgid "Smart Dashes"
+msgstr "ئىدراكلىق سىزىقچە"
+
+msgid "Smart Links"
+msgstr "ئىدراكلىق ئۇلانما"
+
+msgid "Text Replacement"
+msgstr "تېكىست ئالماشتۇرۇش"
+
+msgid "Transformations"
+msgstr "ئۆزگىرىش"
+
+msgid "Make Upper Case"
+msgstr "چوڭ ھەرپكە ئۆزگەرت"
+
+msgid "Make Lower Case"
+msgstr "كىچىك ھەرپكە ئۆزگەرت"
+
+msgid "Capitalize"
+msgstr "چوڭ ھەرپ"
+
+msgid "Speech"
+msgstr "تاۋۇش"
+
+msgid "Start Speaking"
+msgstr "سۆزلەشنى باشلا"
+
+msgid "Stop Speaking"
+msgstr "سۆزلەشنى توختات"
+
+msgid "&View"
+msgstr "ﻛﯚﺭﯛﻧﯜﺵ(&V)"
+
+#. TRANSLATORS: This must be the same as OS X's translation of this View menu item
+msgid "Show Toolbar"
+msgstr "قورال بالداقنى كۆرسەت"
+
+#. TRANSLATORS: This must be the same as OS X's translation of this View menu item
+msgid "Customize Toolbar…"
+msgstr "ئىختىيارىچە قورال بالداق"
+
+#. TRANSLATORS: This must be the same as OS X's translation of this View menu item
+msgid "Enter Full Screen"
+msgstr "پۈتۈن ئېكرانغا كىر"
+
+msgid "Window"
+msgstr "كۆزنەك"
+
+msgid "Minimize"
+msgstr "كىچىكلەت"
+
+msgid "Zoom"
+msgstr "يېقىنلات يىراقلات"
+
+msgid "Welcome to Poedit"
+msgstr "Poedit غا مەرھابا"
+
+msgid "Bring All to Front"
+msgstr "ھەممىسىنى ئەڭ ئالدىغا قوي"
+
+msgid "Information about the translator"
+msgstr "تەرجىمان ھەققىدىكى ئۇچۇر"
+
+msgid "Name:"
+msgstr "ئاتى:"
+
+msgid "Your Name"
+msgstr "ئاتىڭىز"
+
+msgid "Email:"
+msgstr "ئېلخەت:"
+
+msgid "you@example.com"
+msgstr "you@example.com"
+
+msgid "Your name and email address are only used to set the Last-Translator header of GNU gettext files."
+msgstr "ئات ۋە ئېلخەت ئادرېسىڭىز GNU gettext ھۆججىتىنىڭ بېشىدىكى ئاخىرقى تەرجىمە قىلغۇچى ئۇچۇرى ئۈچۈن ئىشلىتىلىدۇ."
+
+msgid "Editing"
+msgstr "تەھرىرلەۋاتىدۇ"
+
+msgid "Automatically compile MO file when saving"
+msgstr "ھۆججەت ساقلىغاندا ئۆزلۈكىدىن .mo ھۆججىتى ھاسىل قىلسۇن"
+
+msgid "Show summary after updating files"
+msgstr "ھۆججەت يېڭىلانغاندىن كېيىن قىسقىچە ئۇچۇر كۆرسەت"
+
+msgid "Check spelling"
+msgstr "ئىملا تەكشۈرۈش"
+
+msgid "Always change focus to text input field"
+msgstr "خەت كىرگۈزۈش رايونىدىكى مەركىزى نۇقتىسىنى دائىم ئۆزگەرت"
+
+msgid "Never let the list of strings take focus. If enabled, you must use Ctrl-arrows for keyboard navigation but you can also type text immediately, without having to press Tab to change focus."
+msgstr "مەركىزى نۇقتىنى ھەرپ تىزمىسى جەدۋىلىدە توختاتماڭ. ئەگەر قوزغاتسىڭىز، چوقۇم Ctrl بىلەن يۆنىلىش كۇنۇپكىسىنى ئىشلىتىپ يول باشلىيالايسىز، ئەمما بۇنداق قىلسىڭىز دەرھال تېكست كىرگۈزەلەيسىز، Tab نى بېسىپ مەركىزىي نۇقتىنى يۆتكىمىسىڭىزمۇ بولىدۇ."
+
+msgid "Appearance"
+msgstr "كۆرۈنۈشى"
+
+msgid "Use custom list font:"
+msgstr "ئىختىيارىچە خەت نۇسخا ئىشلىتىش:"
+
+msgid "Use custom text fields font:"
+msgstr "ئىختىيارىچە تېكىست بۆلىكى خەت نۇسخا ئىشلىتىش:"
+
+msgid "Change UI language"
+msgstr "كۆرۈنۈش تىلىنى ئۆزگەرت"
+
+#. TRANSLATORS: This is a note appended to "Check spelling" when running on older Windows versions
+msgid "(requires Windows 8 or newer)"
+msgstr "(Windows 8 ياكى يېڭى نەشرى زۆرۈر)"
+
+msgid "General"
+msgstr "ئادەتتىكى"
+
+msgid "Use translation memory"
+msgstr "تەرجىمە خاتىرىسىنى ئىشلەت"
+
+msgid "Manage…"
+msgstr "باشقۇرۇش…"
+
+#. TRANSLATORS: Followed by "match translations within the file" or "pre-translate from TM"
+msgid "When updating from sources"
+msgstr "مەنبەدىن يېڭىلىغاندا"
+
+#. TRANSLATORS: Preceded by "When updating from sources"
+msgid "fuzzy match within the file"
+msgstr "ھۆججەتتىكى مۈجىمەل ماس كەلگىنى"
+
+#. TRANSLATORS: Preceded by "When updating from sources"
+msgid "pre-translate from TM"
+msgstr "تەرجىمە خاتىرىسىدىن ئالدىن تەرجىمە"
+
+msgid ""
+"Poedit can attempt to fill in new entries from only previous translations in the file or from your entire translation memory. Using the TM won’t be very effective if it’s near-empty, but it will get better as you add more translations to it."
+msgstr "Poedit ئىلگىرىكى تەرجىمە ھۆججىتى ياكى پۈتكۈل تەرجىمە خاتىرىڭىزگە ئاساسەن يېڭى بۆلەكنى تولدۇرۇشنى سىنايدۇ.   ئاساسەن بوش بولغان تەرجىمە خاتىرىسىنى ئىشلىتىشنىڭ ئانچە ئۈنۈمى بولمايدۇ، بىراق ئۇنىڭغا تېخىمۇ كۆپ تەرجىمە قوشسىڭىز ئۇ ياخشىلىنىدۇ."
+
+msgid "Stored translations:"
+msgstr "ساقلانغان تەرجىمە:"
+
+msgid "Database size on disk:"
+msgstr "دىسكىدىكى ساندان چوڭلۇقى:"
+
+msgid "Import Translation Files…"
+msgstr "تەرجىمە ھۆججىتىنى ئەكىر…"
+
+msgid "Import translation files…"
+msgstr "تەرجىمە ھۆججىتىنى ئەكىر…"
+
+msgid "Import From TMX…"
+msgstr "TMX تىن ئەكىر…"
+
+msgid "Import from TMX…"
+msgstr "TMX تىن ئەكىر…"
+
+msgid "Export To TMX…"
+msgstr "TMX كە چىقار…"
+
+msgid "Export to TMX…"
+msgstr "TMX كە چىقار…"
+
+#. TRANSLATORS: This is a button that deletes everything in the translation memory (i.e. clears/resets it).
+msgid "Reset"
+msgstr "ئەسلىگە قايتۇر"
+
+msgid "Select translation files to import"
+msgstr "ئەكىرىدىغان تەرجىمە ھۆججىتىنى تاللاڭ"
+
+msgid "Translation Memory"
+msgstr "تەرجىمە خاتىرىسى"
+
+msgid "Importing translations…"
+msgstr "تەرجىمىنى ئەكىرىۋاتىدۇ…"
+
+#, c-format
+msgid "Error loading translation file “%s”."
+msgstr "تەرجىمە ھۆججەت «%s» نى يۈكلەشتە خاتالىق كۆرۈلدى."
+
+msgid "Finalizing…"
+msgstr "يەكۈنلەۋاتىدۇ…"
+
+msgid "Select TMX files to import"
+msgstr "ئەكىرىدىغان TMX ھۆججىتىنى تاللاڭ"
+
+msgid "TMX Files"
+msgstr "TMX ھۆججەتلەر"
+
+#, c-format
+msgid "Importing translation memory from “%s” failed."
+msgstr "تەرجىمە خاتىرىسىنى «%s» دىن ئەكىرەلمىدى."
+
+msgid "Import error"
+msgstr "ئەكىرىش خاتالىقى"
+
+msgid "Exporting translations…"
+msgstr "تەرجىمىنى چىقىرىۋاتىدۇ…"
+
+#, c-format
+msgid "Exporting translation memory to “%s” failed."
+msgstr "تەرجىمە خاتىرىسىنى «%s» غا چىقىرالمىدى."
+
+msgid "Export error"
+msgstr "چىقىرىش خاتالىقى"
+
+msgid "Reset translation memory"
+msgstr "تەرجىمە خاتىرىسىنى ئەسلىگە قايتۇر"
+
+msgid "Are you sure you want to reset the translation memory?"
+msgstr "تەرجىمە خاتىرىسىنى راستلا ئەسلىگە قايتۇرامسىز؟"
+
+msgid "Resetting the translation memory will irrevocably delete all stored translations from it. You can’t undo this operation."
+msgstr "تەرجىمە خاتىرىسى ئەسلىگە قايتۇرۇلسا ساقلانغان بارلىق تەرجىمىنىڭ ھەممىسى پۈتۈنلەي ئۆچۈرۈلىدۇ. بۇ مەشغۇلاتتىن يېنىۋالالمايسىز."
+
+#. TRANSLATORS: This is abbreviation of "Translation Memory" used in Preferences on macOS.
+#. Long text looks weird there, too short (like TM) too, but less so. "General" is about ideal
+#. length there.
+msgid "TM"
+msgstr "TM"
+
+msgid "Source code extractors are used to find translatable strings in the source code files and extract them so that they can be translated."
+msgstr "مەنبە كود ئاجراتقۇچ مەنبە كودتىكى تەرجىمە قىلغىلى بولىدىغان ھەرپ تىزىقىنى ئىزدەپ ۋە ئۇلارنى ئاجرىتىشقا ئىشلىتىلىدۇ، شۇڭلاشقا ئۇلارنى تەرجىمە قىلغىلى بولىدۇ."
+
+msgid "Custom Extractors:"
+msgstr "ئىختىيارىچە ئاجراتقۇچ:"
+
+msgid "Custom extractors:"
+msgstr "ئىختىيارىچە ئاجراتقۇچ:"
+
+msgid "GNU gettext"
+msgstr "GNU gettext"
+
+msgid "Supports all programming languages recognized by GNU gettext tools (PHP, C/C++, C#, Perl, Python, Java, JavaScript and others)."
+msgstr "GNU gettext قورالى تونۇيالايدىغان بارلىق پىروگرامما تىللىرى (PHP, C/C++, C#, Perl, Python, Java, JavaScript ۋە باشقىلار) نى قوللايدۇ."
+
+msgid "Delete extractor"
+msgstr "ئاجراتقۇچنى ئۆچۈر"
+
+#, c-format
+msgid "Are you sure you want to delete the “%s” extractor?"
+msgstr "«%s» يەشكۈچنى راستلا ئۆچۈرەمسىز؟"
+
+msgid "Extractors"
+msgstr "ئاجراتقۇچ"
+
+msgid "Accounts"
+msgstr "ھېساباتلار"
+
+msgid "Automatically check for updates"
+msgstr "يېڭىلاشنى ئاپتوماتىك تەكشۈرسۇن"
+
+msgid "Include beta versions"
+msgstr "سىناق نەشرىمۇ ئىچىدە"
+
+msgid "Beta versions contain the latest new features and improvements, but may be a bit less stable."
+msgstr "سىناق نەشرىدە ئەڭ يېڭى ئىقتىدار ۋە ياخشىلاشنى ئۆز ئىچىگە ئالىدۇ، ئەمما ئازراق مۇقىم بولماسلىقى مۇمكىن."
+
+msgid "Updates"
+msgstr "يېڭىلانمىلار"
+
+msgid "These settings affect internal formatting of PO files. Adjust them if you have specific requirements e.g. because of version control."
+msgstr "بۇ تەڭشەكلەر PO ھۆججەتلەرنىڭ ئىچكى پىچىمىغا تەسىر كۆرسىتىدۇ. ئەگەر سىزنىڭ مۇئەييەن تەلىپىڭىز مەسىلەن نەشر تىزگىنلەش، ئۇلارنى تەڭشەڭ."
+
+msgid "Line endings:"
+msgstr "قۇر ئاخىرى:"
+
+msgid "Unix (recommended)"
+msgstr "Unix (تەۋسىيە)"
+
+msgid "Windows"
+msgstr "كۆزنەكلەر"
+
+#. TRANSLATORS: Followed by text control for entering number; wraps text at given width
+msgid "Wrap at:"
+msgstr "قۇر قاتلاش ئورنى:"
+
+msgid "Preserve formatting of existing files"
+msgstr "مەۋجۇت ھۆججەتنىڭ پىچىمىنى ساقلاپ قالىدۇ"
+
+msgid "Advanced"
+msgstr "ئالىي"
+
+msgid "Preparing strings…"
+msgstr "ھەرپ تىزىقىنى تەييارلاۋاتىدۇ…"
+
+msgid "Pre-translating from translation memory…"
+msgstr "تەرجىمە خاتىرىسىدىن ئالدىن تەرجىمە قىلىۋاتىدۇ…"
+
+#, c-format
+msgid "Pre-translated %u string"
+msgid_plural "Pre-translated %u strings"
+msgstr[0] "ئالدىن تەرجىمە قىلىنغىنى %u تىزىق "
+
+msgid "Pre-translating…"
+msgstr "ئالدىن تەرجىمە قىلىۋاتىدۇ…"
+
+msgid "Cannot pre-translate without source text."
+msgstr "مەنبە تېكىستسىز ئالدىن تەرجىمە قىلالمايدۇ."
+
+#. TRANSLATORS: This is a somewhat common term describing the action where
+#. you apply the translation memory and/or machine translation to all of the
+#. strings you're translating as the first step, followed by correcting,
+#. improving etc., i.e. actually translating the strings. This may be tricky
+#. to express in other languages as simply as in English, but please try to
+#. keep it similarly concise. Please try to avoid, if possible, describing it
+#. as "auto-translation" and similar, because such terminology would mislead
+#. some users into thinking it's all that needs to be done (spoken from
+#. experience). "Pre-translate" nicely expresses that it's only the step done
+#. *before* actual translation.
+msgid "Pre-translate"
+msgstr "ئالدىن تەرجىمە"
+
+msgid "Pre-translation requires that source text is available. It doesn’t work if only IDs without the actual text are used."
+msgstr "ئالدىن تەرجىمە قىلىش ئۈچۈن مەنبە تېكىستىنى ئىشلەتكىلى بولۇشى كېرەك. ئەگەر ئەمەلىي تېكىست بولماي ID لا ئىشلىتىلسە ئىشلىمەيدۇ."
+
+msgid "Cannot pre-translate from unknown language."
+msgstr "نامەلۇم تىلدىن ئالدىن تەرجىمە قىلالمايدۇ."
+
+msgid "Pre-translation requires that source text’s language is known. Poedit couldn’t detect it in this file."
+msgstr "ئالدىن تەرجىمە قىلىش ئۈچۈن مەنبە تېكىستنىڭ تىلى ئېنىق بولۇشى كېرەك. Poedit بۇ ھۆججەتتىن ئۇنى بايقىيالمىدى."
+
+msgid "Only fill in exact matches"
+msgstr "تولۇق ماس كەلگەننىلا تولدۇر"
+
+msgid "By default, inaccurate results are also included, but marked as needing work. Check this option to only include perfect matches."
+msgstr "كۆڭۈلدىكى ھالەتتە، خاتا نەتىجىلەرمۇ بار، ئەمما ئىشلەش زۆرۈر بەلگىسى قويۇلدى. پەقەت مۇكەممەل ماسلاشتۇرۇش ئۈچۈن بۇ تاللانما تاللىنىدۇ."
+
+msgid "Don’t mark exact matches as needing work"
+msgstr "دەل ماسلاشقانغا ئىشلەش زۆرۈر بەلگىسى سالما"
+
+msgid "Only enable if you trust the quality of your TM. By default, all matches from the TM are marked as needing work and should be reviewed before use."
+msgstr "پەقەت ئۆزىڭىزنىڭ تەرجىمە خاتىرە سۈپىتىڭىزگە ئىشەنگەندىلا ئاندىن قوزغىتىڭ. كۆڭۈلدىكى ئەھۋالدا، تەرجىمە خاتىرىسىدە ماس كەلگەن ھەممىسىگە ئىشلەش زۆرۈر بەلگىسى قويۇلىدۇ ھەمدە ئىشلىتىشتىن ئىلگىرى قايتا تەكشۈرۈش كېرەك."
+
+msgid "Pre-translation automatically finds exact or fuzzy matches for untranslated strings in the translation memory and fills in their translations."
+msgstr "ئالدىن تەرجىمە تەرجىمە خاتىرىسىدىكى دەل ياكى مۈجمەل ماس كەلگەن تەرجىمە قىلمىغان تىزىقلارنى ئۆزلۈكىدىن ئىزدەپ تېپىپ ۋە ئۇلارنىڭ تەرجىمىسىنى تولدۇرىدۇ."
+
+#, c-format
+msgid "%d entry was pre-translated."
+msgid_plural "%d entries were pre-translated."
+msgstr[0] "%d تىزىق ئالدىن تەرجىمە قىلىندى."
+
+msgid "The translations were marked as needing work, because they may be inaccurate. You should review them for correctness."
+msgstr "تەرجىمىگە ئىشلەش زۆرۈر بەلگىسى سېلىنغان، چۈنكى ئۇلار توغرا بولماسلىقى مۇمكىن.  ئۇلارنىڭ توغرىلىقىنى تەكشۈرۈڭ."
+
+msgid "No entries could be pre-translated."
+msgstr "ئالدىن تەرجىمە قىلغىلى بولىدىغان تۈر يوق."
+
+msgid "The TM doesn’t contain any strings similar to the content of this file. It is only effective for semi-automatic translations after Poedit learns enough from files that you translated manually."
+msgstr "تەرجىمە خاتىرىسىدە بۇ ھۆججەت مەزمۇنىغا ئوخشاپ كېتىدىغان ھېچقانداق ھەرپ تىزىقىنى ئۆز ئىچىگە ئالمىغان.  Poedit تەرجىمىڭىزدىن يېتەرلىك ئۆگەنگەندىن كېيىن ئاندىن يېرىم ئاپتوماتىك تەرجىمىدە رولىنى جارى قىلدۇرىدۇ."
+
+msgid "Cancelling…"
+msgstr "ۋاز كېچىۋاتىدۇ…"
+
+msgid "Drag Folders or Files Here"
+msgstr "قىسقۇچ ياكى ھۆججەتنى بۇ جايغا سۆرەڭ"
+
+msgid "Drag folders or files here"
+msgstr "قىسقۇچ ياكى ھۆججەتنى بۇ جايغا سۆرەڭ"
+
+msgid "Add Folders…"
+msgstr "قىسقۇچ قوش…"
+
+msgid "Add folders…"
+msgstr "قىسقۇچ قوش…"
+
+msgid "Add Files…"
+msgstr "ھۆججەت قوش…"
+
+msgid "Add files…"
+msgstr "ھۆججەت قوش…"
+
+msgid "Add Wildcard…"
+msgstr "ئورتاق بەلگە قوش…"
+
+msgid "Add wildcard…"
+msgstr "ئورتاق بەلگە قوش…"
+
+#. TRANSLATORS: Used on macOS, should match standard translation of this in other apps (incl. name of the Finder app)
+msgid "Reveal in Finder"
+msgstr "ئىزدىگۈچتە كۆرسەت"
+
+#. TRANSLATORS: Used on Windows to show in the Explorer file manager, should match standard translation of "Explorer"
+msgid "Show in Explorer"
+msgstr "مەنبە باشقۇرغۇچتا كۆرسەت"
+
+msgid "Show in Folder"
+msgstr "قىسقۇچتا كۆرسەت"
+
+msgid "Paths"
+msgstr "يول"
+
+msgid "Excluded paths"
+msgstr "مۇستەسنا يول"
+
+msgid "Advanced extraction settings"
+msgstr "ئالىي ئاجرىتىش تەڭشەكلەر"
+
+msgid "Extract notes for translators from:"
+msgstr "تەرجىمانغا ئىزاھاتنى ئاجرىتىش ئورنى:"
+
+msgid "Comments prefixed with:"
+msgstr "ئالدى قوشۇلغۇچى ئىزاھاتى:"
+
+msgid "All comments"
+msgstr "ھەممە ئىزاھاتلار"
+
+msgid "Additional xgettext flags:"
+msgstr "قوشۇمچە xgettext بەلگىسى:"
+
+msgid "Additional keywords"
+msgstr "قوشۇمچە ئاچقۇچلۇق سۆز"
+
+msgid "Name of the project the translation is for"
+msgstr "تەرجىمە قىلىدىغان قۇرۇلۇشنىڭ ئىسمى"
+
+msgid "Team name and email address or URL"
+msgstr "قوشۇن ئىسمى ۋە ئېلخەت ئادرېسى ياكى تور ئادرېسى"
+
+msgid "e.g. nplurals=2; plural=(n > 1);"
+msgstr "مەسىلەن: nplurals=2; plural=(n > 1);"
+
+msgid "UTF-8 (recommended)"
+msgstr "UTF-8 (تەۋسىيە)"
+
+msgid "Please save the file first. This section cannot be edited until then."
+msgstr "ئالدى بىلەن ھۆججەتنى ساقلاڭ.  تۆۋەندىكى مەزمۇنلارنى ئۇنىڭدىن ئىلگىرى تەھرىرلىگىلى بولمايدۇ."
+
+msgid "Placeholders correctness"
+msgstr "ئورۇن بەلگىسى توغرىلىقى"
+
+#, c-format
+msgid "Placeholder “%s” is missing from translation."
+msgstr "تەرجىمىدە ئورۇن بەلگىسى «%s»  كەم."
+
+#, c-format
+msgid "Superfluous placeholder “%s” that isn’t in source text."
+msgstr "مەنبە تېكىستتە بولمىغان ئارتۇقچە ئورۇن بەلگىسى «%s»."
+
+msgid "Plural form translations"
+msgstr "كۆپلۈك شەكلى تەرجىمىسى"
+
+msgid "Not all plural forms are translated."
+msgstr "كۆپلۈك شەكىللىرىنىڭ ھەممىسىنى تەرجىمە قىلمىسىڭىزمۇ بولىدۇ."
+
+msgid "Inconsistent upper/lower case"
+msgstr "چوڭ/كىچىك ھەرپ بىردەك ئەمەس"
+
+msgid "The translation should start as a sentence."
+msgstr "تەرجىمە جۈملە بىلەن باشلىنىدۇ."
+
+msgid "The translation should start with a lowercase character."
+msgstr "تەرجىمە كىچىك ھەرپ بىلەن باشلىنىدۇ."
+
+msgid "Inconsistent whitespace"
+msgstr "باغلاشمىغان بوشلۇق"
+
+msgid "The translation doesn’t start with a space."
+msgstr "تەرجىمە بوشلۇقتىن باشلانمايدۇ."
+
+msgid "The translation starts with a space, but the source text doesn’t."
+msgstr "تەرجىمە بوشلۇق بىلەن باشلانغان، ئەمما ئەسلى تېكىست ئۇنداق ئەمەس."
+
+msgid "The translation is missing a newline at the end."
+msgstr "تەرجىمە ئاخىرىدا يېڭى بىر قۇر كەم."
+
+msgid "The translation ends with a newline, but the source text doesn’t."
+msgstr "تەرجىمە يېڭى قۇر بىلەن ئاخىرلاشقان، ئەمما ئەسلى تېكىستتە ئۇنداق ئەمەس."
+
+msgid "The translation is missing a space at the end."
+msgstr "تەرجىمە ئاخىرىدا بىر بوشلۇق كەم."
+
+msgid "The translation ends with a space, but the source text doesn’t."
+msgstr "تەرجىمە بوشلۇق بىلەن ئاخىرلاشقان، ئەمما ئەسلى تېكىست ئۇنداق ئەمەس."
+
+msgid "Punctuation checks"
+msgstr "تىنىش بەلگە تەكشۈرۈش"
+
+#, c-format
+msgid "The translation should end with “%s”."
+msgstr "تەرجىمە «%s» بىلەن ئاخىرلىشىشى كېرەك."
+
+#, c-format
+msgid "The translation should not end with “%s”."
+msgstr "تەرجىمە «%s» بىلەن ئاخىرلاشماسلىقى كېرەك."
+
+#, c-format
+msgid "The translation ends with “%s”, but the source text ends with “%s”."
+msgstr "تەرجىمە «%s» بىلەن ئاخىرلاشقان، ئەمما ئەسلى تېكىست «%s» بىلەن ئاخىرلاشقان."
+
+msgid "Clear Menu"
+msgstr "تىزىملىكنى تازىلا"
+
+msgid "Clear menu"
+msgstr "تىزىملىكنى تازىلا"
+
+msgid "Comment:"
+msgstr "ئىزاھات:"
+
+msgid "Update"
+msgstr "يېڭىلا"
+
+msgid "&Delete"
+msgstr "ئۆچۈر(&D)"
+
+msgid "Delete the comment"
+msgstr "ئىزاھاتنى ئۆچۈر"
+
+msgid "Edit project"
+msgstr "قۇرۇلۇش تەھرىر"
+
+msgid "Project name:"
+msgstr "قۇرۇلۇش ئاتى:"
+
+msgid "Browse"
+msgstr "كۆز يۈگۈرت"
+
+msgid "Add directory to the list"
+msgstr "تىزىملىككە مۇندەرىجە قوش"
+
+msgid "OK"
+msgstr "جەزملە"
+
+msgid "&File"
+msgstr "ھۆججەت(&F)"
+
+msgid "&New…"
+msgstr "يېڭى(&N)…"
+
+msgid "New from &POT/PO file…"
+msgstr "&POT/PO ھۆججەتتىن يېڭىدىن قۇر…"
+
+msgid "New From &POT/PO File…"
+msgstr "&POT/PO ھۆججەتتىن يېڭىدىن قۇر…"
+
+msgid "&Open…"
+msgstr "ئاچ(&O)…"
+
+msgid "Open Recent"
+msgstr "يېقىنقىنى ئاچ"
+
+msgid "Open recent"
+msgstr "يېقىنقىنى ئاچ"
+
+msgid "Open cloud translation…"
+msgstr "بۇلۇت تەرجىمىسىنى ئاچ…"
+
+msgid "Open Cloud Translation…"
+msgstr "بۇلۇت تەرجىمىسىنى ئاچ…"
+
+msgid "&Start window"
+msgstr "باشلاش كۆزنىكى(&S)"
+
+msgid "&Start Window"
+msgstr "باشلاش كۆزنىكى(&S)"
+
+msgid "Catalogs &manager"
+msgstr "كاتالوگ باشقۇرغۇچ(&M)"
+
+msgid "Catalogs &Manager"
+msgstr "كاتالوگ باشقۇرغۇچ(&M)"
+
+msgid "&Close"
+msgstr "ياپ(&C)"
+
+msgid "&Save"
+msgstr "ساقلا(&S)"
+
+msgid "Save &as…"
+msgstr "باشقا ئاتتا ساقلا(&A)…"
+
+msgid "Save &As…"
+msgstr "باشقا ئاتتا ساقلا(&A)…"
+
+msgid "Compile to MO…"
+msgstr "MO ھاسىللا…"
+
+msgid "E&xport as HTML…"
+msgstr "HTML سۈپىتىدە چىقار(&X)…"
+
+msgid "Check for updates…"
+msgstr "يېڭىلاشنى تەكشۈر…"
+
+msgid "&Preferences…"
+msgstr "مايىللىق(&P)…"
+
+msgid "E&xit"
+msgstr "ﭼﯧﻜﯩﻦ(&X)"
+
+msgid "Quit"
+msgstr "چېكىن"
+
+msgid "Copy from singular"
+msgstr "بىرلىكتىن كۆچۈر"
+
+msgid "Copy From Singular"
+msgstr "بىرلىكتىن كۆچۈر"
+
+msgid "Translation needs &work"
+msgstr "تەرجىمىگە ئىشلەش زۆرۈر(&W)"
+
+msgid "Translation Needs &Work"
+msgstr "تەرجىمىگە ئىشلەش زۆرۈر(&W)"
+
+msgid "Edit &comment"
+msgstr "ئىزاھات تەھرىر(&C)"
+
+msgid "Edit &Comment"
+msgstr "ئىزاھات تەھرىر(&C)"
+
+#. TRANSLATORS: as in: translation suggestions, suggested translations; should be similarly short
+msgid "Suggestions"
+msgstr "تەۋسىيەلەر"
+
+msgid "&Find…"
+msgstr "ئىزدە…(&F)"
+
+msgid "Replace…"
+msgstr "ئالماشتۇر…"
+
+msgid "Find next"
+msgstr "تېكىستتىن ئىزدە"
+
+msgid "Find previous"
+msgstr "ئالدىنقىنى ئىزدە"
+
+msgid "Find and Replace…"
+msgstr "ئىزدە ۋە ئالماشتۇر…"
+
+msgid "Find Next"
+msgstr "كېيىنكىنى ئىزدە"
+
+msgid "Find Previous"
+msgstr "ئالدىنقىنى ئىزدە"
+
+msgid "&Preferences"
+msgstr "مايىللىق(&P)"
+
+msgid "Show string &ID"
+msgstr "تىزىق &ID نى كۆرسەت"
+
+msgid "Show String &ID"
+msgstr "تىزىق &ID نى كۆرسەت"
+
+msgid "Show warnings"
+msgstr "ئاگاھلاندۇرۇشنى كۆرسەت"
+
+msgid "Show Warnings"
+msgstr "ئاگاھلاندۇرۇشنى كۆرسەت"
+
+msgid "Sort by &file order"
+msgstr "ھۆججەت تەرتىپى بويىچە تەرتىپلە(&A)"
+
+msgid "Sort by &File Order"
+msgstr "ھۆججەت تەرتىپى بويىچە تەرتىپلە(&A)"
+
+msgid "Sort by &source"
+msgstr "مەنبە بويىچە تەرتىپلە(&S)"
+
+msgid "Sort by &Source"
+msgstr "مەنبە بويىچە تەرتىپلە(&S)"
+
+msgid "Sort by &translation"
+msgstr "تەرجىمە بويىچە تەرتىپلە(&T)"
+
+msgid "Sort by &Translation"
+msgstr "تەرجىمە بويىچە تەرتىپلە(&T)"
+
+msgid "&Group by context"
+msgstr "تىل مۇھىتى بويىچە گۇرۇپپىلا(&G)"
+
+msgid "&Group By Context"
+msgstr "تىل مۇھىتى بويىچە گۇرۇپپىلا(&G)"
+
+msgid "Entries with errors first"
+msgstr "خاتالىق بار تۈرلەر ئالدىدا"
+
+msgid "Entries with Errors First"
+msgstr "خاتالىق بار تۈرلەر ئالدىدا"
+
+msgid "&Untranslated entries first"
+msgstr "تەرجىمە قىلىنمىغان بىرىنچى تۈر(&U)"
+
+msgid "&Untranslated Entries First"
+msgstr "تەرجىمە قىلىنمىغان بىرىنچى تۈر(&U)"
+
+msgid "&Show code occurrences"
+msgstr "كودنىڭ كۆرۈنىدىغان ئورنىنى كۆرسەت(&S)"
+
+msgid "&Show Code Occurrences"
+msgstr "كودنىڭ كۆرۈنىدىغان ئورنىنى كۆرسەت(&S)"
+
+msgid "Show sidebar"
+msgstr "يان بالداقنى كۆرسەت"
+
+msgid "Show status bar"
+msgstr "ھالەت بالداقنى كۆرسەت"
+
+msgid "&Translation"
+msgstr "تەرجىمە(&T)"
+
+msgid "&Update from source code"
+msgstr "ئەسلى كودتىن يېڭىلا(&U)"
+
+msgid "&Update from Source Code"
+msgstr "ئەسلى كودتىن يېڭىلا(&U)"
+
+msgid "Update from &POT file…"
+msgstr "&POT ھۆججەتتىن يېڭىلا…"
+
+msgid "Update from &POT File…"
+msgstr "&POT ھۆججەتتىن يېڭىلا…"
+
+msgid "Sync with Crowdin"
+msgstr "Crowdin بىلەن قەدەمداشلا"
+
+msgid "Pre-&translate…"
+msgstr "ئالدىن تەرجىمە(&T)…"
+
+msgid "&Purge deleted translations"
+msgstr "ئۆچۈرۈلگەن تەرجىمىنى تازىلا(&P)"
+
+msgid "&Purge Deleted Translations"
+msgstr "ئۆچۈرۈلگەن تەرجىمىنى تازىلا(&P)"
+
+msgid "&Validate translations"
+msgstr "تەرجىمىلەرنى دەلىللە(&V)"
+
+msgid "&Validate Translations"
+msgstr "تەرجىمىلەرنى دەلىللە(&V)"
+
+msgid "&Properties…"
+msgstr "خاسلىق(&P)…"
+
+msgid "&Done and next"
+msgstr "تامام ۋە كېيىنكى(&D)"
+
+msgid "&Done and Next"
+msgstr "تامام ۋە كېيىنكى(&D)"
+
+msgid "Previously edited"
+msgstr "ئىلگىرى تەھرىرلەنگەن"
+
+msgid "Previously Edited"
+msgstr "ئىلگىرى تەھرىرلەنگەن"
+
+msgid "&Previous translation"
+msgstr "ئالدىنقى تەرجىمە(&P)"
+
+msgid "&Previous Translation"
+msgstr "ئالدىنقى تەرجىمە(&P)"
+
+msgid "&Next translation"
+msgstr "كېيىنكى تەرجىمە(&N)"
+
+msgid "&Next Translation"
+msgstr "كېيىنكى تەرجىمە(&N)"
+
+msgid "P&revious unfinished"
+msgstr "ئالدىنقى تاماملانمىغىنى(&R)"
+
+msgid "P&revious Unfinished"
+msgstr "ئالدىنقى تاماملانمىغىنى(&R)"
+
+msgid "Ne&xt unfinished"
+msgstr "كېيىنكى تاماملانمىغىنى(&X)"
+
+msgid "Ne&xt Unfinished"
+msgstr "كېيىنكى تاماملانمىغىنى(&X)"
+
+msgid "Previous plural form"
+msgstr "ئالدىنقى كۆپلۈك شەكلى"
+
+msgid "Previous Plural Form"
+msgstr "ئالدىنقى كۆپلۈك شەكلى"
+
+msgid "Next plural form"
+msgstr "كېيىنكى كۆپلۈك شەكلى"
+
+msgid "Next Plural Form"
+msgstr "كېيىنكى كۆپلۈك شەكلى"
+
+msgid "&Online help"
+msgstr "توردىكى ياردەم(&O)"
+
+msgid "&Online Help"
+msgstr "توردىكى ياردەم(&O)"
+
+msgid "&GNU gettext manual"
+msgstr "&GNU gettext قوللانمىسى"
+
+msgid "&GNU gettext Manual"
+msgstr "&GNU gettext قوللانمىسى"
+
+msgid "&About Poedit"
+msgstr "Poedit ھەققىدە(&A)"
+
+msgid "&About"
+msgstr "ھەققىدە(&A)"
+
+msgid "Extractor setup"
+msgstr "ئاجراتقۇچ ئورنات"
+
+msgid "List of extensions separated by semicolons (e.g. *.cpp;*.h):"
+msgstr "تىزىملىكتىكى كېڭەيتىلگەن نام پەش بىلەن ئايرىلىدۇ (مەسىلەن: *.cpp;*.h):"
+
+msgid "Invocation:"
+msgstr "يۆتكەپ ئىشلىتىش جەريانى:"
+
+msgid "Command to extract translations:"
+msgstr "تەرجىمە ئاجرىتىش بۇيرۇقى:"
+
+msgid ""
+"This is the command used to launch the extractor.\n"
+"%o expands to the name of output file, %K to list\n"
+"of keywords, %F to list of input files,\n"
+"%C to charset flag (see below)."
+msgstr ""
+"بۇ ئاجراتقۇچنى قوزغىتىدىغان بۇيرۇق.\n"
+"%o ئاجرىتىپ چىقىرىدىغان ھۆججەتنىڭ ئاتى، %K،\n"
+"ئاچقۇچلۇق سۆز تىزىمى، %F\n"
+"كىرگۈزىدىغان ھۆججەتنىڭ تىزىمى، %C \n"
+"ھەرپ توپلىمى تىزىمى (تۆۋەندىن كۆرۈڭ)."
+
+msgid "An item in keywords list:"
+msgstr "ھالقىلىق سۆز تىزىملىكىدىكى بىر تۈر:"
+
+msgid ""
+"This will be attached to the command line once\n"
+"for each keyword. %k expands to the keyword."
+msgstr ""
+"ھەر بىر ھالقىلىق سۆزگە قارىتا  يۇقىرىدىكى مەزمۇن بۇيرۇق\n"
+"قۇرىنىڭ  كەينىگە قوشۇلىدۇ.  %k  ھالقىلىق سۆز  بولۇپ يېشىلىدۇ.."
+
+msgid "An item in input files list:"
+msgstr "ھۆججەت تىزىملىكى كىرگۈزۈشتىكى بىر تۈر:"
+
+#, c-format
+msgid ""
+"This will be attached to the command line once\n"
+"for each input file. %f expands to the filename."
+msgstr ""
+"كىرگۈزگەن ھەر بىر ھۆججەتكە نىسبەتەن يۇقىرىدىكى مەزمۇن بۇيرۇق\n"
+"قۇرىنىڭ  كەينىگە قوشۇلىدۇ.  %f  ھۆججەت نامى  بولۇپ يېشىلىدۇ."
+
+msgid "Source code charset:"
+msgstr "مەنبە كودىنىڭ كودلىنىشى:"
+
+#, c-format
+msgid ""
+"This will be attached to the command line\n"
+"only if source code charset was given. %c expands to charset value."
+msgstr "پەقەت مەنبە كود ھەرپ توپلىمىدا بەلگىلىگەندىلا ئاندىن بۇيرۇق قۇرىغا قوشۇلىدۇ. %c ھەرپ توپلىمى قىممىتى قىلىپ يېشىلىدۇ."
+
+msgid "Translation Properties"
+msgstr "تەرجىمە خاسلىقى"
+
+msgid "Project name and version:"
+msgstr "قۇرۇلۇش ئاتى ۋە نەشرى:"
+
+msgid "Language team:"
+msgstr "تىل قوشۇنى:"
+
+msgid "Plural forms:"
+msgstr "كۆپلۈك شەكلى:"
+
+msgid "Use default rules for this language"
+msgstr "بۇ تىلنىڭ كۆڭۈلدىكى قائىدىسىنى ئىشلەت"
+
+msgid "Use custom expression"
+msgstr "ئىختىيارىچە ئىپادە ئىشلەت"
+
+msgid "Learn about plural forms"
+msgstr "كۆپلۈك ھەققىدە بىلدۈرگۈ"
+
+msgid "Charset:"
+msgstr "كودلاش:"
+
+msgid "Advanced Extraction Settings…"
+msgstr "ئالىي ئاجرىتىش تەڭشەكلەر…"
+
+msgid "Advanced extraction settings…"
+msgstr "ئالىي ئاجرىتىش تەڭشەكلەر…"
+
+msgid "Translation properties"
+msgstr "تەرجىمە خاسلىقى"
+
+msgid "Sources Paths"
+msgstr "مەنبە يول"
+
+msgid "Sources paths"
+msgstr "مەنبە يول"
+
+msgid "Extract text from source files in the following directories:"
+msgstr "تېكىستنى مەنبە ھۆججەتتىن تۆۋەندىكى مۇندەرىجىگە چىقار:"
+
+msgid "Base path:"
+msgstr "ئاساسىي يول:"
+
+msgid "Sources Keywords"
+msgstr "مەنبە ئاچقۇچلۇق سۆز"
+
+msgid "Sources keywords"
+msgstr "مەنبە ئاچقۇچلۇق سۆز"
+
+msgid ""
+"Use these keywords (function names) to recognize translatable strings\n"
+"in source files:"
+msgstr "بۇ ئاچقۇچلۇق سۆزلەر (فۇنكىتسىيە نامى)نى ئىشلىتىش ئارقىلىق مەنبە ھۆججەتلەردىكى تەرجىمە قىلغىلى بولىدىغان ھەرپ تىزمىسىنى  تونۇيدۇ:"
+
+msgid "Also use default keywords for supported languages"
+msgstr "قوللايدىغان تىللارغىمۇ كۆڭۈلدىكى ئاچقۇچلۇق سۆزنى ئىشلىتىدۇ"
+
+msgid "Learn about gettext keywords"
+msgstr "Gettext ئاچقۇچلۇق سۆز ھەققىدە بىلدۈرگۈ"
+
+msgid "Update summary"
+msgstr "قىسقىچە مەزمۇننى يېڭىلا"
+
+msgid ""
+"These strings were found in the sources but were not in the file.\n"
+"Poedit will add them to the file now."
+msgstr ""
+"ئەسلى مەنبەدىن بۇ تىزىقلار بايقالدى ئەمما ھۆججەتتە يوق.\n"
+"ھازىر Poedit ئۇلارنى ھۆججەتكە قوشىدۇ."
+
+msgid "New strings"
+msgstr "يېڭى ھەرپ تىزمىسى"
+
+msgid ""
+"These strings are no longer in the source code.\n"
+"Poedit will remove them from the file now."
+msgstr ""
+"ئەمدى بۇ تىزىقلار مەنبە كودىدا يوق.\n"
+"ھازىر Poedit ئۇلارنى ھۆججەتتىن چىقىرىۋېتىدۇ."
+
+msgid "Obsolete strings"
+msgstr "كونا ھەرپ تىزمىسى"
+
+msgid "(0 new, 0 obsolete)"
+msgstr "(0 يېڭى، 0 كونا)"
+
+msgid "Open"
+msgstr "ئاچ"
+
+msgid "Open file"
+msgstr "ھۆججەت ئاچ"
+
+msgid "Save file"
+msgstr "ھۆججەت ساقلا"
+
+msgid "Validate"
+msgstr "دەلىللەش"
+
+msgid "Check for errors in the translation"
+msgstr "تەرجىمىدىكى خاتالىقلارنى تەكشۈر"
+
+msgid "Update from code"
+msgstr "كودتىن يېڭىلا"
+
+msgid "Update from Code"
+msgstr "كودتىن يېڭىلا"
+
+msgid "Update from source code"
+msgstr "ئەسلى كودتىن يېڭىلا"
+
+msgid "Sidebar"
+msgstr "يان بالداق"
+
+msgid "Show or hide the sidebar"
+msgstr "يان بالداقنى كۆرسەت ياكى يوشۇر"
+
+#. TRANSLATORS: "Previous" as in used in the past, now replaced with newer.
+msgid "Previous source text"
+msgstr "ئالدىنقى مەنبە تېكست"
+
+msgid "The old source text (before it changed during an update) that the now-inaccurate translation corresponds to."
+msgstr "ھازىرقى توغرا بولمىغان تەرجىمىگە مۇناسىپ كونا ئەسلى تېكىست (بۇ قېتىملىق يېڭىلاشتىن ئىلگىرى ئۆزگەرتىلگەن)"
+
+msgid "Notes for translators"
+msgstr "تەرجىمانلارغا ئىزاھات"
+
+msgid "Comment"
+msgstr "ئىزاھات"
+
+msgid "Add comment"
+msgstr "ئىزاھات قوش"
+
+msgid "Add Comment"
+msgstr "ئىزاھات قوش"
+
+msgid "Delete From Translation Memory"
+msgstr "تەرجىمە خاتىرىسىدىن ئۆچۈر"
+
+msgid "Delete from translation memory"
+msgstr "تەرجىمە خاتىرىسىدىن ئۆچۈر"
+
+msgid "Translation suggestions"
+msgstr "تەرجىمە تەۋسىيەلىرى"
+
+#. TRANSLATORS: This is shown when no translation suggestions can be found in the TM (Windows).
+msgid "No matches found"
+msgstr "ماس كەلگەنلىرى تېپىلمىدى"
+
+#. TRANSLATORS: This is shown when no translation suggestions can be found in the TM (macOS, Linux).
+msgid "No Matches Found"
+msgstr "ماس كەلگىنى تېپىلمىدى"
+
+msgid "This string was found in Poedit’s translation memory."
+msgstr "بۇ تىزىق Poedit نىڭ تەرجىمە خاتىرىسىدە بايقالدى."
+
+msgid "Translation suggestions require that source text is available. They don’t work if only IDs without the actual text are used."
+msgstr "تەرجىمە تەۋسىيەسى ئۈچۈن مەنبە تېكىستىنى ئىشلەتكىلى بولۇشى كېرەك. ئەگەر ئەمەلىي تېكىست بولماي ID لا ئىشلىتىلسە ئۇلار ئىشلىمەيدۇ."
+
+msgid "Translation suggestions require that source text’s language is known. Poedit couldn’t detect it in this file."
+msgstr "تەرجىمە تەۋسىيەسى ئۈچۈن مەنبە تېكىستنىڭ تىلى ئېنىق بولۇشى كېرەك. Poedit بۇ ھۆججەتتىن ئۇنى بايقىيالمىدى."
+
+msgid "The TMX file is malformed."
+msgstr "بۇ TMX ھۆججىتىنىڭ پىچىمى خاتا."
+
+msgid "No translations were found in the TMX file."
+msgstr "بۇ TMX ھۆججىتىدە ھېچقانداق تەرجىمە تېپىلمىدى."
+
+#, c-format
+msgid "Translation memory database is corrupted: %s (%d)."
+msgstr "تەرجىمە خاتىرە ساندانى بۇزۇلدى: %s (%d)."
+
+#, c-format
+msgid "Translation memory error: %s (%d)."
+msgstr "تەرجىمە خاتىرىسى خاتالىقى: %s (%d)."
+
+msgid "Cannot create temporary directory."
+msgstr "ۋاقىتلىق  قىسقۇچىنى قۇرالمىدى."
+
+msgid "There are no translations. That’s unusual."
+msgstr "تەرجىمىسى يوق.  بۇ ئادەتتىكىدەك ئەمەس."
+
+msgid ""
+"Translatable entries aren’t added manually in the Gettext system, but are automatically extracted\n"
+"from source code. This way, they stay up to date and accurate.\n"
+"Translators typically use PO template files (POTs) prepared for them by the developer."
+msgstr ""
+"تەرجىمە تۈرى Gettext سىستېمىسىدا قولدا كىرگۈزۈلمەيدۇ، ئەمما مەنبە كودتىن ئۆزلۈكىدىن ئاجرىتىلىدۇ. بۇنداق بولغاندا، ئەڭ يېڭى ۋە ئەڭ توغرا بولغان تەرجىمە قىلىشقا تېگىشلىك تۈرلەرنى بىلەلەيمىز.\n"
+"تەرجىمانلار ئادەتتە ئىجادكارلار ئۇلارغا تەييارلاپ بەرگەن PO قېلىپ ھۆججەت (POT) نى ئىشلىتىدۇ."
+
+msgid "(Learn more about GNU gettext)"
+msgstr "(GNU gettext ھەققىدە تېخىمۇ كۆپ ئۇچۇر)"
+
+msgid "The simplest way to fill this file with translations is to update it from a POT:"
+msgstr "بۇ ھۆججەتنىڭ تەرجىمىسىنى تولدۇرۇشنىڭ قۇلاي يولى ئۇنى POT تىن يېڭىلاش:"
+
+msgid "Update from POT"
+msgstr "POT تىن يېڭىلا"
+
+msgid "Take translatable strings from an existing POT template."
+msgstr "مەۋجۇت POT قېلىپىدىن تەرجىمە قىلغىلى بولىدىغان تىزىقنى ئاجرىتىدۇ."
+
+msgid "You can also extract translatable strings directly from the source code:"
+msgstr "مەنبە كودتىن تەرجىمە قىلغىلى بولىدىغان ھەرپ تىزىقلىرىنى بىۋاسىتە ئاجرىتالايسىز:"
+
+msgid "Extract from sources"
+msgstr "مەنبەدىن ياي"
+
+msgid "Configure source code extraction in Properties."
+msgstr "خاسلىقىدا ئەسلى كود ئاجرىتىش سەپلىمىسى."
+
+#. TRANSLATORS: This is version information in about dialog, "%s" will be
+#. version number when used
+#, c-format
+msgid "Version %s"
+msgstr "نەشرى %s"
+
+msgid "Create new"
+msgstr "يېڭىدىن قۇر"
+
+msgid "Create new translation from POT template."
+msgstr "يېڭى تەرجىمىنى POT قېلىپىدىن قۇرىدۇ."
+
+msgid "Browse files"
+msgstr "ھۆججەتكە كۆز يۈگۈرت"
+
+msgid "Open and edit translation files."
+msgstr "تەرجىمە ھۆججەتلەرنى ئېچىپ ۋە تەھرىرلەيدۇ."
+
+msgid "Translate cloud project"
+msgstr "بۇلۇت قۇرۇلۇشى تەرجىمىسى"
+
+msgid "Collaborate with other people online."
+msgstr "توردىكى باشقا كىشىلەر بىلەن ھەمكارلىشىڭ."
+
+msgid "Recent files"
+msgstr "يېقىنقى ھۆججەتلەر"
+
+msgid "Sync"
+msgstr "قەدەمداشلا"
+
+msgid "Synchronize the translation with Crowdin"
+msgstr "تەرجىمىنى Crowdin بىلەن قەدەمداشلايدۇ"
+
+#. TRANSLATORS: This is titlebar of about dialog, "%s" is application name
+#. ("Poedit" here, but please use "%s")
+#, c-format
+msgid "About %s"
+msgstr "%s ھەققىدە"
+
+#. TRANSLATORS: Title of the preferences window on Windows and Linux. "%s" is replaced with "Poedit" when running.
+#, c-format
+msgid "%s Preferences"
+msgstr "%s مايىللىقلار"
+
+#. TRANSLATORS: macOS item in app menu
+msgid "Services"
+msgstr "مۇلازىمەتلەر"
+
+#. TRANSLATORS: macOS item in app menu, %s is replaced with "Poedit"
+#, c-format
+msgid "Hide %s"
+msgstr "%s نى يوشۇر"
+
+#. TRANSLATORS: macOS item in app menu
+msgid "Hide Others"
+msgstr "باشقىلارنى يوشۇر"
+
+#. TRANSLATORS: macOS item in app menu
+msgid "Show All"
+msgstr "ھەممىنى كۆرسەت"
+
+#. TRANSLATORS: macOS item in app menu, %s is replaced with "Poedit"
+#, c-format
+msgid "Quit %s"
+msgstr "%s چېكىن"
+
+#. TRANSLATORS: macOS item in app menu
+msgid "Preferences…"
+msgstr "مايىللىق…"
+
+msgid "Preferences..."
+msgstr "مايىللىق…"
+
+#. TRANSLATORS: Title of a category in Windows task menu (right-click icon in taskbar)
+msgid "Recent"
+msgstr "يېقىنقى"
+
+#. TRANSLATORS: Title of a category in Windows task menu (right-click icon in taskbar)
+msgid "Frequent"
+msgstr "دائىم"
+
+msgid "&Apply"
+msgstr "قوللان(&A)"
+
+msgid "Apply"
+msgstr "قوللان"
+
+msgid "&Back"
+msgstr "كەينى(&B)"
+
+msgid "Back"
+msgstr "قايت"
+
+msgid "&Cancel"
+msgstr "ۋاز كەچ(&C)"
+
+msgid "&Clear"
+msgstr "تازىلا(&C)"
+
+msgid "Clear"
+msgstr "تازىلا"
+
+msgid "Copy"
+msgstr "كۆچۈر"
+
+msgid "Cu&t"
+msgstr "كەس(&T)"
+
+msgid "Cut"
+msgstr "كەس"
+
+msgid "Edit"
+msgstr "تەھرىر"
+
+msgid "&Quit"
+msgstr "چېكىن(&Q)"
+
+msgid "Help"
+msgstr "ياردەم"
+
+msgid "&New"
+msgstr "يېڭى(&N)"
+
+msgid "New"
+msgstr "يېڭى"
+
+msgid "&No"
+msgstr "ياق(&N)"
+
+msgid "No"
+msgstr "ياق"
+
+msgid "&OK"
+msgstr "جەزملە(&O)"
+
+msgid "Open…"
+msgstr "ئاچ…"
+
+msgid "&Open..."
+msgstr "ئاچ(&O)…"
+
+msgid "Open..."
+msgstr "ئاچ…"
+
+msgid "&Paste"
+msgstr "چاپلا(&P)"
+
+msgid "Paste"
+msgstr "چاپلا"
+
+msgid "Preferences"
+msgstr "مايىللىق"
+
+msgid "&Redo"
+msgstr "قايتىلا(&R)"
+
+msgid "Refresh"
+msgstr "يېڭىلا"
+
+msgid "&Save as"
+msgstr "باشقا ئاتتا ساقلا(&S)"
+
+msgid "Save as"
+msgstr "باشقا ئاتتا ساقلا"
+
+msgid "Select &All"
+msgstr "ھەممىنى تاللا(&A)"
+
+msgid "Select All"
+msgstr "ھەممىنى تاللا"
+
+msgid "&Undo"
+msgstr "يېنىۋال(&U)"
+
+msgid "&Yes"
+msgstr "ھەئە(&Y)"
+
+msgid "Yes"
+msgstr "ھەئە"
+
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Shift+"
+msgstr "Shift+"
+
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Enter"
+msgstr "Enter"
+
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Up"
+msgstr "ئۈستى"
+
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Down"
+msgstr "ئاستى"
+
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Left"
+msgstr "سول"
+
+#. TRANSLATORS: Keyboard shortcut for display in Windows menus
+msgid "Right"
+msgstr "ئوڭ"
+
+#. TRANSLATORS: Keyboard shortcut, must correspond to translation of "Ctrl+"
+msgid "ctrl"
+msgstr "ctrl"
+
+#. TRANSLATORS: Keyboard shortcut, must correspond to translation of "Alt+"
+msgid "alt"
+msgstr "alt"
+
+#. TRANSLATORS: Keyboard shortcut, must correspond to translation of "Shift+"
+msgid "shift"
+msgstr "shift"


### PR DESCRIPTION
Please correct Uyghur language pluralforms for Poedit to:

nplurals=1; plural=0;

http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html?id=l10n/pluralforms language name:
ئۇيغۇرچە Uyghur UG

Thanks

~