### PR TITLE
Add astro to supported extensions for Javascript

### DIFF
--- a/scripts/extract-fileviewer-mappings.py
+++ b/scripts/extract-fileviewer-mappings.py
@@ -22,6 +22,7 @@ OVERRIDES = {
     'h'     : 'cpp',
     'inc'   : 'php',
     'cake'  : 'coffeescript',
+    'astro' : 'javascript',
     'es'    : 'javascript',
     'fcgi'  : 'lua',
     'cgi'   : 'perl',


### PR DESCRIPTION
Hey!

Thanks for Poedit (: I am using the proversion and am currently in the process of writing a skeleton / tutorial for how to setup a SEO friendly multilingual project with Astro and po-files.

Astro is a very quickly growing and already big framework for creating SSG'd websites. It's pages have an extension of `.astro` but contain mainly js / tsx.

My tutorial will feature how to do the basic setup with gettext and show how Poedit can be used for the actual translation. It's nearly done and I will link it within this PR soonish.

It would be cool if I could explain how to use poedit, without needing to require profeatures to beginners. I think the only missing part for that is the extension-support.

Edit: Here is the project I was talking about https://suven.github.io/astro-po-i18n/ 