### PR TITLE
Use static IDs for controls needed by NVDA

### DIFF
--- a/Poedit.vcxproj
+++ b/Poedit.vcxproj
@@ -241,6 +241,7 @@
     <ClInclude Include="src\recent_files.h" />
     <ClInclude Include="src\sidebar.h" />
     <ClInclude Include="src\spellchecking.h" />
+    <ClInclude Include="src\static_ids.h" />
     <ClInclude Include="src\str_helpers.h" />
     <ClInclude Include="src\syntaxhighlighter.h" />
     <ClInclude Include="src\text_control.h" />

--- a/Poedit.vcxproj.filters
+++ b/Poedit.vcxproj.filters
@@ -425,6 +425,9 @@
     <ClInclude Include="src\app_updates.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\static_ids.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src\poedit.rc">

--- a/Poedit.xcodeproj/project.pbxproj
+++ b/Poedit.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		B224558419A3B11400120FFE /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B224558619A3B16300120FFE /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = gl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B224558819A3B18D00120FFE /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/MoveApplication.strings; sourceTree = "<group>"; };
+		B228096E2C4AD007005F2CA3 /* static_ids.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = static_ids.h; sourceTree = "<group>"; };
 		B2284A50183BE3B300E097C7 /* PFMoveApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PFMoveApplication.h; path = deps/letsmove/PFMoveApplication.h; sourceTree = "<group>"; };
 		B2284A51183BE3B300E097C7 /* PFMoveApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PFMoveApplication.m; path = deps/letsmove/PFMoveApplication.m; sourceTree = "<group>"; };
 		B2284A54183BE68200E097C7 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -813,6 +814,7 @@
 				B2DFCCFA19B5FD15003DFAD0 /* sidebar.h */,
 				B2F25F0C199E327C00127FF9 /* spellchecking.cpp */,
 				B2F25F0B199E23B300127FF9 /* spellchecking.h */,
+				B228096E2C4AD007005F2CA3 /* static_ids.h */,
 				B2E2184A199A76B100EA2784 /* syntaxhighlighter.cpp */,
 				B2E2184B199A76B100EA2784 /* syntaxhighlighter.h */,
 				B2E11F101A2C66FB00E4E42C /* text_control.cpp */,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,6 +66,7 @@ poedit_SOURCES = \
                  recent_files.cpp recent_files.h \
                  sidebar.cpp sidebar.h \
                  spellchecking.h spellchecking.cpp \
+                 static_ids.h \
                  str_helpers.h \
                  syntaxhighlighter.cpp syntaxhighlighter.h \
                  text_control.h text_control.cpp \

--- a/src/attentionbar.cpp
+++ b/src/attentionbar.cpp
@@ -67,7 +67,7 @@ AttentionBar::AttentionBar(wxWindow *parent)
 #ifdef __WXMSW__
     m_icon = new wxStaticBitmap(this, wxID_ANY, wxNullBitmap);
 #endif
-    m_label = new AutoWrappingText(this, "");
+    m_label = new AutoWrappingText(this, wxID_ANY, "");
     m_explanation = new ExplanationLabel(this, "");
     m_buttons = new wxBoxSizer(wxHORIZONTAL);
     m_checkbox = new wxCheckBox(this, wxID_ANY, "");

--- a/src/customcontrols.cpp
+++ b/src/customcontrols.cpp
@@ -273,7 +273,7 @@ SelectableAutoWrappingText::SelectableAutoWrappingText(wxWindow *parent, const w
     gtk_label_set_selectable(view, TRUE);
 #else
     // at least allow copying
-    static wxWindowID idCopy = wxNewId();
+    static wxWindowIDRef idCopy = NewControlId();
     Bind(wxEVT_CONTEXT_MENU, [=](wxContextMenuEvent&){
         wxMenu menu;
         menu.Append(idCopy, _("&Copy"));

--- a/src/customcontrols.cpp
+++ b/src/customcontrols.cpp
@@ -165,8 +165,8 @@ HeadingLabel::HeadingLabel(wxWindow *parent, const wxString& label)
 }
 
 
-AutoWrappingText::AutoWrappingText(wxWindow *parent, const wxString& label)
-    : wxStaticText(parent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE),
+AutoWrappingText::AutoWrappingText(wxWindow *parent, wxWindowID winid, const wxString& label)
+    : wxStaticText(parent, winid, "", wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE),
       m_text(label),
       m_wrapWidth(-1)
 {
@@ -262,8 +262,8 @@ bool AutoWrappingText::RewrapForWidth(int width)
 }
 
 
-SelectableAutoWrappingText::SelectableAutoWrappingText(wxWindow *parent, const wxString& label)
-    : AutoWrappingText(parent, label)
+SelectableAutoWrappingText::SelectableAutoWrappingText(wxWindow *parent, wxWindowID winid, const wxString& label)
+    : AutoWrappingText(parent, winid, label)
 {
 #if defined(__WXOSX__)
     NSTextField *view = (NSTextField*)GetHandle();
@@ -288,7 +288,7 @@ SelectableAutoWrappingText::SelectableAutoWrappingText(wxWindow *parent, const w
 
 
 ExplanationLabel::ExplanationLabel(wxWindow *parent, const wxString& label)
-    : AutoWrappingText(parent, label)
+    : AutoWrappingText(parent, wxID_ANY, label)
 {
 #if defined(__WXOSX__) || defined(__WXGTK__)
     SetWindowVariant(wxWINDOW_VARIANT_SMALL);

--- a/src/customcontrols.h
+++ b/src/customcontrols.h
@@ -55,7 +55,7 @@ public:
 class AutoWrappingText : public wxStaticText
 {
 public:
-    AutoWrappingText(wxWindow *parent, const wxString& label);
+    AutoWrappingText(wxWindow *parent, wxWindowID winid, const wxString& label);
 
     void SetLanguage(Language lang);
     void SetAlignment(TextDirection dir);
@@ -121,7 +121,7 @@ private:
 class SelectableAutoWrappingText : public AutoWrappingText
 {
 public:
-    SelectableAutoWrappingText(wxWindow *parent, const wxString& label);
+    SelectableAutoWrappingText(wxWindow *parent, wxWindowID winid, const wxString& label);
 };
 
 

--- a/src/editing_area.cpp
+++ b/src/editing_area.cpp
@@ -32,6 +32,7 @@
 #include "edlistctrl.h"
 #include "hidpi.h"
 #include "spellchecking.h"
+#include "static_ids.h"
 #include "text_control.h"
 #include "utility.h"
 
@@ -179,11 +180,11 @@ public:
         Ellipsize
     };
 
-    TagLabel(wxWindow *parent, Color fg, Color bg) : wxWindow(parent, wxID_ANY)
+    TagLabel(wxWindow *parent, Color fg, Color bg, wxWindowID labelChildID = wxID_ANY) : wxWindow(parent, wxID_ANY)
     {
         m_icon = nullptr;
 
-        m_label = new wxStaticText(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+        m_label = new wxStaticText(this, labelChildID, "", wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
 #ifdef __WXOSX__
         m_label->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 #endif
@@ -299,7 +300,7 @@ class EditingArea::IssueLabel : public EditingArea::TagLabel
 {
 public:
     IssueLabel(wxWindow *parent)
-        : TagLabel(parent, Color::TagErrorLineFg, Color::TagErrorLineBg)
+        : TagLabel(parent, Color::TagErrorLineFg, Color::TagErrorLineBg, WinID::TranslationIssueText)
     {
         m_iconError = wxArtProvider::GetBitmap("StatusErrorBlack");
         m_iconWarning = wxArtProvider::GetBitmap("StatusWarningBlack");
@@ -497,7 +498,7 @@ void EditingArea::CreateEditControls(wxBoxSizer *sizer)
     // "needs review" implies that somebody else should review the string after
     // I am done with it (i.e. consider it good), while "needs work" implies I
     // need to return to it and finish the translation.
-    m_fuzzy = new SwitchButton(this, wxID_ANY, MSW_OR_OTHER(_("Needs work"), _("Needs Work")));
+    m_fuzzy = new SwitchButton(this, WinID::NeedsWorkSwitch, MSW_OR_OTHER(_("Needs work"), _("Needs Work")));
 #ifdef __WXOSX__
     m_fuzzy->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 #endif

--- a/src/prefsdlg.cpp
+++ b/src/prefsdlg.cpp
@@ -493,10 +493,10 @@ private:
 
     void OnManageTM(wxCommandEvent& e)
     {
-        static const auto idLearn = wxNewId();
-        static const auto idImportTMX = wxNewId();
-        static const auto idExportTMX = wxNewId();
-        static const auto idReset = wxNewId();
+        static wxWindowIDRef idLearn = NewControlId();
+        static wxWindowIDRef idImportTMX = NewControlId();
+        static wxWindowIDRef idExportTMX = NewControlId();
+        static wxWindowIDRef idReset = NewControlId();
 
         wxMenu menu;
 #ifdef __WXOSX__

--- a/src/propertiesdlg.cpp
+++ b/src/propertiesdlg.cpp
@@ -396,9 +396,9 @@ protected:
 
     void OnAddMenu(wxCommandEvent& e)
     {
-        static const auto idFolder = wxNewId();
-        static const auto idFile = wxNewId();
-        static const auto idWild = wxNewId();
+        static wxWindowIDRef idFolder = NewControlId();
+        static wxWindowIDRef idFile = NewControlId();
+        static wxWindowIDRef idWild = NewControlId();
 
         wxMenu *menu = new wxMenu();
 #ifdef __WXOSX__
@@ -473,7 +473,7 @@ protected:
 
         event.Skip(false);
 
-        static wxWindowID idShowInFolder = wxNewId();
+        static wxWindowIDRef idShowInFolder = NewControlId();
         wxMenu menu;
         auto menuItem = menu.Append(idShowInFolder,
 #if defined(__WXOSX__)

--- a/src/recent_files.cpp
+++ b/src/recent_files.cpp
@@ -460,7 +460,7 @@ protected:
     };
 
 private:
-    const wxWindowID m_idClear = wxNewId();
+    wxWindowIDRef m_idClear = wxWindow::NewControlId();
 
     file_icons_ptr m_icons_cache;
     MyHistory m_history;

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -474,7 +474,7 @@ private:
 
         auto sidebar = m_sidebar;
         auto suggestion = m_value;
-        static const auto idDelete = wxNewId();
+        static wxWindowIDRef idDelete = NewControlId();
 
         wxMenu menu;
 #ifdef __WXOSX__

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -136,7 +136,7 @@ public:
         m_innerSizer->Add(new ExplanationLabel(parent, _("The old source text (before it changed during an update) that the now-inaccurate translation corresponds to.")),
                      wxSizerFlags().Expand());
         m_innerSizer->AddSpacer(PX(5));
-        m_text = new SelectableAutoWrappingText(parent, "");
+        m_text = new SelectableAutoWrappingText(parent, wxID_ANY, "");
         m_innerSizer->Add(m_text, wxSizerFlags().Expand());
     }
 
@@ -162,7 +162,7 @@ public:
         : SidebarBlock(parent, _("Notes for translators"))
     {
         m_innerSizer->AddSpacer(PX(5));
-        m_comment = new SelectableAutoWrappingText(parent, "");
+        m_comment = new SelectableAutoWrappingText(parent, wxID_ANY, "");
         m_innerSizer->Add(m_comment, wxSizerFlags().Expand());
     }
 
@@ -195,7 +195,7 @@ public:
         : SidebarBlock(parent, _("Comment"))
     {
         m_innerSizer->AddSpacer(PX(5));
-        m_comment = new SelectableAutoWrappingText(parent, "");
+        m_comment = new SelectableAutoWrappingText(parent, wxID_ANY, "");
         m_innerSizer->Add(m_comment, wxSizerFlags().Expand());
     }
 
@@ -266,7 +266,7 @@ public:
         m_parentBlock = block;
         m_isHighlighted = false;
         m_icon = new StaticBitmap(this, "SuggestionTMTemplate");
-        m_text = new AutoWrappingText(this, "TEXT");
+        m_text = new AutoWrappingText(this, wxID_ANY, "TEXT");
         m_info = new InfoStaticText(this);
         m_moreActions = new ImageButton(this, "DownvoteTemplate");
 

--- a/src/sidebar.cpp
+++ b/src/sidebar.cpp
@@ -33,6 +33,7 @@
 #include "configuration.h"
 #include "errors.h"
 #include "hidpi.h"
+#include "static_ids.h"
 #include "utility.h"
 #include "unicode_helpers.h"
 
@@ -136,7 +137,7 @@ public:
         m_innerSizer->Add(new ExplanationLabel(parent, _("The old source text (before it changed during an update) that the now-inaccurate translation corresponds to.")),
                      wxSizerFlags().Expand());
         m_innerSizer->AddSpacer(PX(5));
-        m_text = new SelectableAutoWrappingText(parent, wxID_ANY, "");
+        m_text = new SelectableAutoWrappingText(parent, WinID::PreviousSourceText, "");
         m_innerSizer->Add(m_text, wxSizerFlags().Expand());
     }
 
@@ -162,7 +163,7 @@ public:
         : SidebarBlock(parent, _("Notes for translators"))
     {
         m_innerSizer->AddSpacer(PX(5));
-        m_comment = new SelectableAutoWrappingText(parent, wxID_ANY, "");
+        m_comment = new SelectableAutoWrappingText(parent, WinID::NotesForTranslator, "");
         m_innerSizer->Add(m_comment, wxSizerFlags().Expand());
     }
 
@@ -195,7 +196,7 @@ public:
         : SidebarBlock(parent, _("Comment"))
     {
         m_innerSizer->AddSpacer(PX(5));
-        m_comment = new SelectableAutoWrappingText(parent, wxID_ANY, "");
+        m_comment = new SelectableAutoWrappingText(parent, WinID::TranslatorComment, "");
         m_innerSizer->Add(m_comment, wxSizerFlags().Expand());
     }
 

--- a/src/static_ids.h
+++ b/src/static_ids.h
@@ -1,0 +1,70 @@
+/*
+ *  This file is part of Poedit (https://poedit.net)
+ *
+ *  Copyright (C) 2024 Vaclav Slavik
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef Poedit_static_ids_h
+#define Poedit_static_ids_h
+
+#include <wx/defs.h>
+
+namespace WinID
+{
+
+/**
+	IDs of all controls in the application that need them fixed.
+
+	This is in small part for code convenience, but primarily to accomodate
+	NVDA screen reader, which needs them to be able to lookup UI elements.
+
+	See https://github.com/vslavik/poedit/issues/845
+
+    See https://github.com/nvaccess/nvda/blob/master/source/appModules/poedit.py
+    for NVDA's Poedit-specific code.
+
+	!!! DO NOT CHANGE NUMERIC VALUES !!!
+ */
+enum ID
+{
+	// Not a real ID; this value is smaller than any actual ID in this list
+	MIN                                          = 10000,
+
+    // Since version 3.5:
+
+	// Menu items in the list's context menu, used for file reference entries
+	ListContextReferencesStart                   = /*10000*/ MIN,
+	ListContextReferencesEnd                     = /*10100*/ ListContextReferencesStart + 100,
+
+
+	// ...enter new IDs here...
+
+	// Not a real ID; this value is larger than any actual ID in this list
+	MAX
+};
+
+static_assert((int)WinID::MIN > (int)wxID_HIGHEST, "static IDs conflict with wxWidgets");
+static_assert((int)WinID::MIN > (int)wxID_AUTO_HIGHEST, "static IDs conflict with wxWidgets");
+
+} // WinID
+
+#endif // Poedit_static_ids_h

--- a/src/static_ids.h
+++ b/src/static_ids.h
@@ -55,6 +55,24 @@ enum ID
 	ListContextReferencesStart                   = /*10000*/ MIN,
 	ListContextReferencesEnd                     = /*10100*/ ListContextReferencesStart + 100,
 
+    // The "Needs work" toggle in editing area at the bottom:
+    NeedsWorkSwitch                              = 10101,
+
+    // The error or warning line above translation field (hidden when there's
+    // no issue; ID is of the static text child window with issue's text):
+    TranslationIssueText                         = 10102,
+
+    // Text of previous source text (msgid) for current item
+    // (shown in sidebar, may be hidden, is static control with the text):
+    PreviousSourceText                           = 10103,
+
+    // Text of notes for translators (extracted from source code) for current item
+    // (shown in sidebar, may be hidden, is static control with the text):
+    NotesForTranslator                           = 10104,
+
+    // Text of translator's comment for current item
+    // (shown in sidebar, may be hidden, is static control with the text):
+    TranslatorComment                            = 10105,
 
 	// ...enter new IDs here...
 

--- a/src/welcomescreen.cpp
+++ b/src/welcomescreen.cpp
@@ -144,7 +144,7 @@ EmptyPOScreenPanel::EmptyPOScreenPanel(PoeditFrame *parent, bool isGettext)
 
     if (isGettext)
     {
-        auto explain = new AutoWrappingText(this, _(L"Translatable entries aren’t added manually in the Gettext system, but are automatically extracted\nfrom source code. This way, they stay up to date and accurate.\nTranslators typically use PO template files (POTs) prepared for them by the developer."));
+        auto explain = new AutoWrappingText(this, wxID_ANY, _(L"Translatable entries aren’t added manually in the Gettext system, but are automatically extracted\nfrom source code. This way, they stay up to date and accurate.\nTranslators typically use PO template files (POTs) prepared for them by the developer."));
         sizer->Add(explain, wxSizerFlags().Expand().Border(wxTOP, PX(10)));
 
         auto learnMore = new LearnMoreLink(this, "http://www.gnu.org/software/gettext/manual/html_node/", _("(Learn more about GNU gettext)"));


### PR DESCRIPTION
This reorganizes Poedit's code to be able to a) assign static IDs safely and b) add more quickly if the need arrises.

See the relevant NVDA plugin's code here: https://github.com/nvaccess/nvda/blob/master/source/appModules/poedit.py

@LeonarddeR I'd appreciate your review if you could spare the time. Most of the changes are internal to Poedit and of little interest, the interesting bit is the `static_id.h` file:

1. Is it understandable?
2. Does it cover NVDA's needs?
3. Can it be improved and/or is there more that you guys need?

I *think* it covers it (`PRO_IDENTIFIER` and `MAIN_SPLITTER_IDENTIFIER` seem to be needed just for the clever/hacky workaround for lack of static IDs), but I'm far from being 100% sure.
