### PR TITLE
Fix appstreamcli validate warnings and info

### DIFF
--- a/net.poedit.Poedit.appdata.xml
+++ b/net.poedit.Poedit.appdata.xml
@@ -14,13 +14,15 @@
         </p>
     </description>
     <screenshots>
-        <screenshot>
+        <screenshot type="default">
             <image type="source">https://poedit.net/images/screenshots/linux/poedit-appdata1.png</image>
         </screenshot>
     </screenshots>
     <url type="homepage">https://poedit.net</url>
     <url type="bugtracker">https://github.com/vslavik/poedit</url>
+    <url type="vcs-browser">https://github.com/vslavik/poedit</url>
     <url type="translate">https://crowdin.com/project/poedit</url>
+    <content_rating type="oars-1.1" />
     <keywords>
         <keyword>translation</keyword>
         <keyword>gettext</keyword>
@@ -38,5 +40,8 @@
     </provides>
 
     <developer_name>Václav Slavík</developer_name>
+    <developer id="net.poedit">
+        <name>Václav Slavík</name>
+    </developer>
     <translation type="gettext">poedit</translation>
 </component>


### PR DESCRIPTION
Fixes the following warnings and info when running the `appstreamcli validate` command on Linux:

- W: screenshot-default-missing
- I: content-rating-missing
- I: developer-info-missing

"I: developer-name-tag-deprecated", which tells use of the `developer_name` tag that was deprecated in AppStream 1.0.0, is not fixed for now because some software centers may not support AppStream 1.0.0 yet.

Originally taken from [the patch on Flathub](https://github.com/flathub/net.poedit.Poedit/blob/b6d901fd89ef09545bbfa74e908dc8419c512fd3/appdata.patch).

---

FYI the current result of the command:

```
ryo@b760m ~/work/tmp/poedit (master =)]$ appstreamcli validate net.poedit.Poedit.appdata.xml
W: net.poedit.Poedit:16: screenshot-default-missing
I: net.poedit.Poedit:40: developer-name-tag-deprecated
I: net.poedit.Poedit:~: content-rating-missing
I: net.poedit.Poedit:~: developer-info-missing

✘ Validation failed: warnings: 1, infos: 3, pedantic: 3
[ryo@b760m ~/work/tmp/poedit (master =)]$ appstreamcli --version
AppStream version: 1.0.2
[ryo@b760m ~/work/tmp/poedit (master =)]$
```