### PR TITLE
Boost.System has been headers only since 1.69.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,8 +56,7 @@ yes)	DEBUG_FLAGS="-g -Wall -O0"
 esac
 
 
-AX_BOOST_BASE([1.60], [], [AC_MSG_ERROR([Boost libraries are required])])
-AX_BOOST_SYSTEM
+AX_BOOST_BASE([1.69], [], [AC_MSG_ERROR([Boost libraries are required])])
 AX_BOOST_THREAD
 CXXFLAGS="$CXXFLAGS $BOOST_CPPFLAGS"
 


### PR DESCRIPTION
The recently released Boost 1.89.0 removed the compatibility stub, so requiring the BOOST_SYSTEM library will now lead to a build failure. This commit also bumps the minimum version of Boost to 1.69.0, as that was the first version where this is headers only.